### PR TITLE
Releasing Beta v0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /obj
 /Releases
 /KerbalSorter
+*.suo
+*.dll

--- a/Hooks/AstronautComplexHook.cs
+++ b/Hooks/AstronautComplexHook.cs
@@ -4,8 +4,7 @@ using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
 
-namespace KerbalSorter.Hooks
-{
+namespace KerbalSorter.Hooks {
     [KSPAddon(KSPAddon.Startup.SpaceCentre, false)]
     public class AstronautComplexHook : MonoBehaviour {
         CMAstronautComplex complex;
@@ -16,7 +15,7 @@ namespace KerbalSorter.Hooks
         CrewPanel curPanel;
 
         protected void Start() {
-            try{
+            try {
                 // Set up hooks:
                 GameEvents.onGUIAstronautComplexSpawn.Add(OnACSpawn);
                 GameEvents.onGUIAstronautComplexDespawn.Add(OnACDespawn);
@@ -25,7 +24,7 @@ namespace KerbalSorter.Hooks
 
                 // Get rosters:
                 complex = UIManager.instance.gameObject.GetComponentsInChildren<CMAstronautComplex>(true).FirstOrDefault();
-                if (complex == null) throw new Exception("Could not find astronaut complex");
+                if( complex == null ) throw new Exception("Could not find astronaut complex");
                 UIScrollList availableCrew = complex.transform.Find("CrewPanels/panel_enlisted/panelManager/panel_available/scrolllist_available").GetComponent<UIScrollList>();
                 UIScrollList assignedCrew = complex.transform.Find("CrewPanels/panel_enlisted/panelManager/panel_assigned/scrolllist_assigned").GetComponent<UIScrollList>();
                 UIScrollList killedCrew = complex.transform.Find("CrewPanels/panel_enlisted/panelManager/panel_kia/scrolllist_kia").GetComponent<UIScrollList>();
@@ -52,17 +51,18 @@ namespace KerbalSorter.Hooks
                 listener.Panel = CrewPanel.Available;
                 listener.Callback = OnTabSwitch;
                 listener.SkipFirstTime = true;
-                
+
                 listener = assignedCrew.gameObject.AddComponent<EnableListener>();
                 listener.Panel = CrewPanel.Assigned;
                 listener.Callback = OnTabSwitch;
                 listener.SkipFirstTime = true;
-                
+
                 listener = killedCrew.gameObject.AddComponent<EnableListener>();
                 listener.Panel = CrewPanel.Killed;
                 listener.Callback = OnTabSwitch;
                 listener.SkipFirstTime = true;
-            } catch( Exception e ){
+            }
+            catch( Exception e ) {
                 Debug.Log("KerbalSorter: Unexpected error in AstronautComplex Hook: " + e);
             }
         }
@@ -73,9 +73,9 @@ namespace KerbalSorter.Hooks
             Transform targetTabTrans = complex.transform.Find("CrewPanels/panel_enlisted/tabs/tab_kia");
             BTPanelTab targetTab = targetTabTrans.GetComponent<BTPanelTab>();
             Vector3 screenPos = Utilities.GetPosition(targetTabTrans);
-            float x = screenPos.x+targetTab.width+5;
+            float x = screenPos.x + targetTab.width + 5;
             float y = screenPos.y - 1;
-            sortBar.SetPos(x,y);
+            sortBar.SetPos(x, y);
 
             sortBar.enabled = true;
         }
@@ -92,15 +92,15 @@ namespace KerbalSorter.Hooks
             Debug.Log("KerbalSorter: OnFire called: "+ kerbal.name + " - " + something);
         }*/
 
-        protected void OnTabSwitch(CrewPanel panel){
-            if( this.curPanel == panel ){
+        protected void OnTabSwitch(CrewPanel panel) {
+            if( this.curPanel == panel ) {
                 return;
             }
             this.curPanel = panel;
 
             StockRoster roster = null;
             KerbalComparer defaultOrder = null;
-            switch( panel ){
+            switch( panel ) {
                 case CrewPanel.Available:
                     roster = this.available;
                     defaultOrder = StandardKerbalComparers.DefaultAvailable;
@@ -138,8 +138,8 @@ namespace KerbalSorter.Hooks
             public Action<CrewPanel> Callback;
             public bool SkipFirstTime = false;
             private bool _doneFirstTime = false;
-            protected void OnEnable(){
-                if( SkipFirstTime && !_doneFirstTime ){
+            protected void OnEnable() {
+                if( SkipFirstTime && !_doneFirstTime ) {
                     _doneFirstTime = true;
                     return;
                 }

--- a/Hooks/AstronautComplexHook.cs
+++ b/Hooks/AstronautComplexHook.cs
@@ -8,7 +8,7 @@ namespace KerbalSorter.Hooks {
     [KSPAddon(KSPAddon.Startup.SpaceCentre, false)]
     public class AstronautComplexHook : MonoBehaviour {
         CMAstronautComplex complex;
-        SortingButtons sortBar;
+        SortBar sortBar;
         StockRoster available;
         StockRoster assigned;
         StockRoster killed;
@@ -38,7 +38,7 @@ namespace KerbalSorter.Hooks {
                 };
 
                 // Initialize the sort bar:
-                sortBar = gameObject.AddComponent<SortingButtons>();
+                sortBar = gameObject.AddComponent<SortBar>();
                 sortBar.SetRoster(available);
                 sortBar.SetButtons(buttons);
                 sortBar.SetDefaultOrdering(StandardKerbalComparers.DefaultAvailable);

--- a/Hooks/AstronautComplexHook.cs
+++ b/Hooks/AstronautComplexHook.cs
@@ -45,8 +45,10 @@ namespace KerbalSorter.Hooks {
                 applicants = new StockRoster(applicantList);
 
                 // Set up button list:
-                SortButtonDef[] buttonsCrew = new SortButtonDef[]{ StandardButtonDefs.ByName,
-                    StandardButtonDefs.ByClass, StandardButtonDefs.ByLevel, StandardButtonDefs.ByGender
+                SortButtonDef[] buttonsCrew = new SortButtonDef[]{
+                    StandardButtonDefs.ByName, StandardButtonDefs.ByClass,
+                    StandardButtonDefs.ByLevel, StandardButtonDefs.ByGender,
+                    StandardButtonDefs.ByNumFlights
                 };
                 SortButtonDef[] buttonsApplicants = new SortButtonDef[]{
                     StandardButtonDefs.ByName, StandardButtonDefs.ByClass, StandardButtonDefs.ByGender

--- a/Hooks/AstronautComplexHook.cs
+++ b/Hooks/AstronautComplexHook.cs
@@ -10,23 +10,28 @@ namespace KerbalSorter.Hooks
     public class AstronautComplexHook : MonoBehaviour {
         CMAstronautComplex complex;
         SortingButtons sortBar;
-        Roster<IUIListObject> available;
-        Roster<IUIListObject> assigned;
-        Roster<IUIListObject> killed;
+        StockRoster available;
+        StockRoster assigned;
+        StockRoster killed;
+        CrewPanel curPanel;
 
         protected void Start() {
             try{
                 // Set up hooks:
                 GameEvents.onGUIAstronautComplexSpawn.Add(OnACSpawn);
                 GameEvents.onGUIAstronautComplexDespawn.Add(OnACDespawn);
+                GameEvents.OnCrewmemberHired.Add(OnHire);
+                //GameEvents.OnCrewmemberSacked.Add(OnFire);
 
                 // Get rosters:
                 complex = UIManager.instance.gameObject.GetComponentsInChildren<CMAstronautComplex>(true).FirstOrDefault();
                 if (complex == null) throw new Exception("Could not find astronaut complex");
                 UIScrollList availableCrew = complex.transform.Find("CrewPanels/panel_enlisted/panelManager/panel_available/scrolllist_available").GetComponent<UIScrollList>();
-                //UIScrollList assignedCrew = complex.transform.Find("CrewPanels/panel_enlisted/panelManager/panel_assigned/scrolllist_assigned").GetComponent<UIScrollList>();
-                //UIScrollList killedCrew = complex.transform.Find("CrewPanels/panel_enlisted/panelManager/panel_kia/scrolllist_kia").GetComponent<UIScrollList>();
+                UIScrollList assignedCrew = complex.transform.Find("CrewPanels/panel_enlisted/panelManager/panel_assigned/scrolllist_assigned").GetComponent<UIScrollList>();
+                UIScrollList killedCrew = complex.transform.Find("CrewPanels/panel_enlisted/panelManager/panel_kia/scrolllist_kia").GetComponent<UIScrollList>();
                 available = new StockRoster(availableCrew);
+                assigned = new StockRoster(assignedCrew);
+                killed = new StockRoster(killedCrew);
 
                 // Set up button list:
                 SortButtonDef[] buttons = new SortButtonDef[]{ StandardButtonDefs.ByName,
@@ -38,6 +43,24 @@ namespace KerbalSorter.Hooks
                 sortBar.SetRoster(available);
                 sortBar.SetButtons(buttons);
                 sortBar.enabled = false;
+                curPanel = CrewPanel.Available;
+
+
+                // Assign enable listeners to the rosters:
+                EnableListener listener = availableCrew.gameObject.AddComponent<EnableListener>();
+                listener.Panel = CrewPanel.Available;
+                listener.Callback = OnTabSwitch;
+                listener.SkipFirstTime = true;
+                
+                listener = assignedCrew.gameObject.AddComponent<EnableListener>();
+                listener.Panel = CrewPanel.Assigned;
+                listener.Callback = OnTabSwitch;
+                listener.SkipFirstTime = true;
+                
+                listener = killedCrew.gameObject.AddComponent<EnableListener>();
+                listener.Panel = CrewPanel.Killed;
+                listener.Callback = OnTabSwitch;
+                listener.SkipFirstTime = true;
             } catch( Exception e ){
                 Debug.Log("KerbalSorter: Unexpected error in AstronautComplex Hook: " + e);
             }
@@ -52,6 +75,7 @@ namespace KerbalSorter.Hooks
             float x = screenPos.x+targetTab.width+5;
             float y = screenPos.y - 1;
             sortBar.SetPos(x,y);
+            OnTabSwitch(CrewPanel.Available);
 
             sortBar.enabled = true;
         }
@@ -60,9 +84,56 @@ namespace KerbalSorter.Hooks
             sortBar.enabled = false;
         }
 
+        protected void OnHire(ProtoCrewMember kerbal, int numActiveKerbals) {
+            sortBar.SortRoster(true);
+        }
+
+        /*protected void OnFire(ProtoCrewMember kerbal, int numActiveKerbals) {
+            Debug.Log("KerbalSorter: OnFire called: "+ kerbal.name + " - " + something);
+        }*/
+
+        protected void OnTabSwitch(CrewPanel panel){
+            if( this.curPanel == panel ){
+                return;
+            }
+            this.curPanel = panel;
+
+            StockRoster roster = null;
+            switch( panel ){
+                case CrewPanel.Available: roster = this.available; break;
+                case CrewPanel.Assigned:  roster = this.assigned; break;
+                case CrewPanel.Killed:    roster = this.killed; break;
+            }
+            sortBar.SetRoster(roster);
+        }
+
         protected void OnDestroy() {
             GameEvents.onGUIAstronautComplexSpawn.Remove(OnACSpawn);
             GameEvents.onGUIAstronautComplexDespawn.Remove(OnACDespawn);
+            GameEvents.OnCrewmemberHired.Remove(OnHire);
+            //GameEvents.OnCrewmemberSacked.Remove(OnFire);
+        }
+
+
+        protected enum CrewPanel {
+            Available,
+            Assigned,
+            Killed
+        }
+
+        // Use: Assign as component to component you want to listen to.
+        protected class EnableListener : MonoBehaviour {
+            public CrewPanel Panel;
+            public Action<CrewPanel> Callback;
+            public bool SkipFirstTime = false;
+            private bool _doneFirstTime = false;
+            protected void OnEnable(){
+                if( SkipFirstTime && !_doneFirstTime ){
+                    _doneFirstTime = true;
+                    return;
+                }
+                Callback(Panel);
+            }
         }
     }
 

--- a/Hooks/AstronautComplexHook.cs
+++ b/Hooks/AstronautComplexHook.cs
@@ -42,6 +42,7 @@ namespace KerbalSorter.Hooks
                 sortBar = gameObject.AddComponent<SortingButtons>();
                 sortBar.SetRoster(available);
                 sortBar.SetButtons(buttons);
+                sortBar.SetDefaultOrdering(StandardKerbalComparers.DefaultAvailable);
                 sortBar.enabled = false;
                 curPanel = CrewPanel.Available;
 
@@ -75,7 +76,6 @@ namespace KerbalSorter.Hooks
             float x = screenPos.x+targetTab.width+5;
             float y = screenPos.y - 1;
             sortBar.SetPos(x,y);
-            OnTabSwitch(CrewPanel.Available);
 
             sortBar.enabled = true;
         }
@@ -99,12 +99,23 @@ namespace KerbalSorter.Hooks
             this.curPanel = panel;
 
             StockRoster roster = null;
+            KerbalComparer defaultOrder = null;
             switch( panel ){
-                case CrewPanel.Available: roster = this.available; break;
-                case CrewPanel.Assigned:  roster = this.assigned; break;
-                case CrewPanel.Killed:    roster = this.killed; break;
+                case CrewPanel.Available:
+                    roster = this.available;
+                    defaultOrder = StandardKerbalComparers.DefaultAvailable;
+                    break;
+                case CrewPanel.Assigned:
+                    roster = this.assigned;
+                    defaultOrder = StandardKerbalComparers.DefaultAssigned;
+                    break;
+                case CrewPanel.Killed:
+                    roster = this.killed;
+                    defaultOrder = StandardKerbalComparers.DefaultKilled;
+                    break;
             }
             sortBar.SetRoster(roster);
+            sortBar.SetDefaultOrdering(defaultOrder);
         }
 
         protected void OnDestroy() {

--- a/Hooks/AstronautComplexHook.cs
+++ b/Hooks/AstronautComplexHook.cs
@@ -63,21 +63,26 @@ namespace KerbalSorter.Hooks {
                 listener.SkipFirstTime = true;
             }
             catch( Exception e ) {
-                Debug.Log("KerbalSorter: Unexpected error in AstronautComplex Hook: " + e);
+                Debug.LogError("KerbalSorter: Unexpected error in AstronautComplexHook: " + e);
             }
         }
 
 
         protected void OnACSpawn() {
-            // Set position:
-            Transform targetTabTrans = complex.transform.Find("CrewPanels/panel_enlisted/tabs/tab_kia");
-            BTPanelTab targetTab = targetTabTrans.GetComponent<BTPanelTab>();
-            Vector3 screenPos = Utilities.GetPosition(targetTabTrans);
-            float x = screenPos.x + targetTab.width + 5;
-            float y = screenPos.y - 1;
-            sortBar.SetPos(x, y);
+            try {
+                // Set position:
+                Transform targetTabTrans = complex.transform.Find("CrewPanels/panel_enlisted/tabs/tab_kia");
+                BTPanelTab targetTab = targetTabTrans.GetComponent<BTPanelTab>();
+                Vector3 screenPos = Utilities.GetPosition(targetTabTrans);
+                float x = screenPos.x + targetTab.width + 5;
+                float y = screenPos.y - 1;
+                sortBar.SetPos(x, y);
 
-            sortBar.enabled = true;
+                sortBar.enabled = true;
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in AstronautComplexHook: " + e);
+            }
         }
 
         protected void OnACDespawn() {
@@ -85,7 +90,12 @@ namespace KerbalSorter.Hooks {
         }
 
         protected void OnHire(ProtoCrewMember kerbal, int numActiveKerbals) {
-            sortBar.SortRoster(true);
+            try {
+                sortBar.SortRoster(true);
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in AstronautComplexHook: " + e);
+            }
         }
 
         /*protected void OnFire(ProtoCrewMember kerbal, int numActiveKerbals) {
@@ -93,36 +103,46 @@ namespace KerbalSorter.Hooks {
         }*/
 
         protected void OnTabSwitch(CrewPanel panel) {
-            if( this.curPanel == panel ) {
-                return;
-            }
-            this.curPanel = panel;
+            try {
+                if( this.curPanel == panel ) {
+                    return;
+                }
+                this.curPanel = panel;
 
-            StockRoster roster = null;
-            KerbalComparer defaultOrder = null;
-            switch( panel ) {
-                case CrewPanel.Available:
-                    roster = this.available;
-                    defaultOrder = StandardKerbalComparers.DefaultAvailable;
-                    break;
-                case CrewPanel.Assigned:
-                    roster = this.assigned;
-                    defaultOrder = StandardKerbalComparers.DefaultAssigned;
-                    break;
-                case CrewPanel.Killed:
-                    roster = this.killed;
-                    defaultOrder = StandardKerbalComparers.DefaultKilled;
-                    break;
+                StockRoster roster = null;
+                KerbalComparer defaultOrder = null;
+                switch( panel ) {
+                    case CrewPanel.Available:
+                        roster = this.available;
+                        defaultOrder = StandardKerbalComparers.DefaultAvailable;
+                        break;
+                    case CrewPanel.Assigned:
+                        roster = this.assigned;
+                        defaultOrder = StandardKerbalComparers.DefaultAssigned;
+                        break;
+                    case CrewPanel.Killed:
+                        roster = this.killed;
+                        defaultOrder = StandardKerbalComparers.DefaultKilled;
+                        break;
+                }
+                sortBar.SetRoster(roster);
+                sortBar.SetDefaultOrdering(defaultOrder);
             }
-            sortBar.SetRoster(roster);
-            sortBar.SetDefaultOrdering(defaultOrder);
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in AstronautComplexHook: " + e);
+            }
         }
 
         protected void OnDestroy() {
-            GameEvents.onGUIAstronautComplexSpawn.Remove(OnACSpawn);
-            GameEvents.onGUIAstronautComplexDespawn.Remove(OnACDespawn);
-            GameEvents.OnCrewmemberHired.Remove(OnHire);
-            //GameEvents.OnCrewmemberSacked.Remove(OnFire);
+            try {
+                GameEvents.onGUIAstronautComplexSpawn.Remove(OnACSpawn);
+                GameEvents.onGUIAstronautComplexDespawn.Remove(OnACDespawn);
+                GameEvents.OnCrewmemberHired.Remove(OnHire);
+                //GameEvents.OnCrewmemberSacked.Remove(OnFire);
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in AstronautComplexHook: " + e);
+            }
         }
 
 
@@ -139,11 +159,16 @@ namespace KerbalSorter.Hooks {
             public bool SkipFirstTime = false;
             private bool _doneFirstTime = false;
             protected void OnEnable() {
-                if( SkipFirstTime && !_doneFirstTime ) {
-                    _doneFirstTime = true;
-                    return;
+                try {
+                    if( SkipFirstTime && !_doneFirstTime ) {
+                        _doneFirstTime = true;
+                        return;
+                    }
+                    Callback(Panel);
                 }
-                Callback(Panel);
+                catch( Exception e ) {
+                    Debug.LogError("KerbalSorter: Unexpected error in AstronautComplexHook: " + e);
+                }
             }
         }
     }

--- a/Hooks/AstronautComplexHook.cs
+++ b/Hooks/AstronautComplexHook.cs
@@ -5,6 +5,9 @@ using System.Linq;
 using System.Collections.Generic;
 
 namespace KerbalSorter.Hooks {
+    /// <summary>
+    /// The main hook for the Astronaut Complex. Started up whenever the Space Centre is loaded.
+    /// </summary>
     [KSPAddon(KSPAddon.Startup.SpaceCentre, false)]
     public class AstronautComplexHook : MonoBehaviour {
         CMAstronautComplex complex;
@@ -14,6 +17,9 @@ namespace KerbalSorter.Hooks {
         StockRoster killed;
         CrewPanel curPanel;
 
+        /// <summary>
+        /// Set up the SortBar for the Astronaut Complex. (Callback)
+        /// </summary>
         protected void Start() {
             try {
                 // Set up hooks:
@@ -68,6 +74,9 @@ namespace KerbalSorter.Hooks {
         }
 
 
+        /// <summary>
+        /// Set the Sort Bar position and enable it on Astronaut Complex spawn. (Callback)
+        /// </summary>
         protected void OnACSpawn() {
             try {
                 // Set position:
@@ -85,10 +94,18 @@ namespace KerbalSorter.Hooks {
             }
         }
 
+        /// <summary>
+        /// Disable the Sort Bar on Astronaut Complex despawn. (Callback)
+        /// </summary>
         protected void OnACDespawn() {
             sortBar.enabled = false;
         }
 
+        /// <summary>
+        /// Resort the lists when a new kerbal is hired. (Callback)
+        /// </summary>
+        /// <param name="kerbal">The kerbal just hired</param>
+        /// <param name="numActiveKerbals">The new number of active kerbals</param>
         protected void OnHire(ProtoCrewMember kerbal, int numActiveKerbals) {
             try {
                 sortBar.SortRoster(true);
@@ -102,6 +119,10 @@ namespace KerbalSorter.Hooks {
             Debug.Log("KerbalSorter: OnFire called: "+ kerbal.name + " - " + something);
         }*/
 
+        /// <summary>
+        /// Switch the list that the Sort Bar operates with on tab change. (Callback)
+        /// </summary>
+        /// <param name="panel">The new panel</param>
         protected void OnTabSwitch(CrewPanel panel) {
             try {
                 if( this.curPanel == panel ) {
@@ -133,6 +154,9 @@ namespace KerbalSorter.Hooks {
             }
         }
 
+        /// <summary>
+        /// Remove GameEvent hooks when this hook is unloaded. (Callback)
+        /// </summary>
         protected void OnDestroy() {
             try {
                 GameEvents.onGUIAstronautComplexSpawn.Remove(OnACSpawn);
@@ -146,13 +170,20 @@ namespace KerbalSorter.Hooks {
         }
 
 
+        /// <summary>
+        /// The panels in the Astronaut Complex's tab control.
+        /// </summary>
         protected enum CrewPanel {
             Available,
             Assigned,
             Killed
         }
 
-        // Use: Assign as component to component you want to listen to.
+
+        /// <summary>
+        /// A hook into any component's OnEnable event.
+        /// </summary>
+        /// Use: Assign, as a component, to the component you want to listen to.
         protected class EnableListener : MonoBehaviour {
             public CrewPanel Panel;
             public Action<CrewPanel> Callback;
@@ -173,6 +204,9 @@ namespace KerbalSorter.Hooks {
         }
     }
 
+    /// <summary>
+    /// A hook for the Astronaut Complex accessed through the editors.
+    /// </summary>
     [KSPAddon(KSPAddon.Startup.EditorAny, false)]
     public class AstronautComplexHook_EditorFix : AstronautComplexHook {
     }

--- a/Hooks/EditorHook.cs
+++ b/Hooks/EditorHook.cs
@@ -13,6 +13,9 @@ namespace KerbalSorter.Hooks
         protected void Start() {
             try{
                 GameEvents.onEditorScreenChange.Add(OnEditorScreenChange);
+                // We actually do need these:
+                GameEvents.onGUIAstronautComplexSpawn.Add(OnACSpawn);
+                GameEvents.onGUIAstronautComplexDespawn.Add(OnACDespawn);
 
                 // Get Roster:
                 UIScrollList[] lists = UIManager.instance.gameObject.GetComponentsInChildren<UIScrollList>(true);
@@ -70,6 +73,8 @@ namespace KerbalSorter.Hooks
 
         protected void OnDestroy() {
             GameEvents.onEditorScreenChange.Remove(OnEditorScreenChange);
+            GameEvents.onGUIAstronautComplexSpawn.Remove(OnACSpawn);
+            GameEvents.onGUIAstronautComplexDespawn.Remove(OnACDespawn);
         }
 
         protected void OnEditorScreenChange(EditorScreen screen) {
@@ -84,6 +89,15 @@ namespace KerbalSorter.Hooks
             } else {
                 sortBar.enabled = false;
             }
+        }
+
+        protected void OnACSpawn(){
+            sortBar.enabled = false;
+        }
+        protected void OnACDespawn()
+        {
+            // When we come out of the AC, we'll be in the Crew Select screen.
+            sortBar.enabled = true;
         }
 
 

--- a/Hooks/EditorHook.cs
+++ b/Hooks/EditorHook.cs
@@ -9,26 +9,47 @@ namespace KerbalSorter.Hooks
     [KSPAddon(KSPAddon.Startup.EditorAny, false)]
     class EditorHook : MonoBehaviour {
         SortingButtons sortBar;
+        UIScrollList availableCrew;
+        UIScrollList vesselCrew;
+        bool fixDefaultAssignment = false;
+        bool loadBtnPressed = false;
+        bool noParts = true;
         
         protected void Start() {
             try{
+                // Game Event Hooks
                 GameEvents.onEditorScreenChange.Add(OnEditorScreenChange);
+                GameEvents.onEditorLoad.Add(OnEditorLoad);
+                GameEvents.onEditorRestart.Add(OnEditorRestart);
+                GameEvents.onEditorShipModified.Add(OnEditorShipModified);
                 // We actually do need these:
                 GameEvents.onGUIAstronautComplexSpawn.Add(OnACSpawn);
                 GameEvents.onGUIAstronautComplexDespawn.Add(OnACDespawn);
 
+
                 // Get Roster:
                 UIScrollList[] lists = UIManager.instance.gameObject.GetComponentsInChildren<UIScrollList>(true);
-                UIScrollList availableCrew = null;
-                foreach( UIScrollList list in lists ){
-                    if (list.name == "scrolllist_avail")
-                    {
+                availableCrew = null;
+                vesselCrew = null;
+                foreach( UIScrollList list in lists ) {
+                    if( list.name == "scrolllist_avail" ) {
                         availableCrew = list;
-                        break;
+                        if( vesselCrew != null ) {
+                            break;
+                        }
+                    }
+                    else if( list.name == "scrolllist_crew" ) {
+                        vesselCrew = list;
+                        if( availableCrew != null ) {
+                            break;
+                        }
                     }
                 }
-                if( availableCrew == null ){
+                if( availableCrew == null ) {
                     throw new Exception("Could not find Available Crew List!");
+                }
+                if( vesselCrew == null ) {
+                    throw new Exception("Could not find Vessel Crew List!");
                 }
                 StockRoster available = new StockRoster(availableCrew);
 
@@ -65,6 +86,29 @@ namespace KerbalSorter.Hooks
                 AnimationClip clip = new AnimationClip();
                 clip.SetCurve("", typeof(Transform), "position.x", curve);
                 sortBar.gameObject.AddComponent<Animation>().AddClip(clip, "flyin");*/
+
+
+                // Add some extra hooks:
+                availableCrew.AddValueChangedDelegate(OnAvailListValueChanged);
+                Transform trans = UIManager.instance.transform.FindChild("panel_CrewAssignmentInEditor");
+                foreach( BTButton btn in trans.GetComponentsInChildren<BTButton>() ){
+                    if( btn.name == "button_reset" ){
+                        btn.AddValueChangedDelegate(OnResetBtn);
+                    }
+                    else if( btn.name == "button_clear" ){
+                        btn.AddValueChangedDelegate(OnClearBtn);
+                    }
+                }
+                trans = UIManager.instance.transform.FindChild("TopRightAnchor");
+                foreach( UIButton btn in trans.GetComponentsInChildren<UIButton>() ) {
+                    if( btn.name == "ButtonLoad" ){
+                        btn.AddValueChangedDelegate(OnLoadBtn);
+                    }
+                }
+
+                fixDefaultAssignment = false;
+                loadBtnPressed = false;
+                noParts = true;
             }
             catch (Exception e){
                 Debug.LogError("KerbalSorter: Unexpected error in Editor Hook! " + e);
@@ -73,10 +117,15 @@ namespace KerbalSorter.Hooks
 
         protected void OnDestroy() {
             GameEvents.onEditorScreenChange.Remove(OnEditorScreenChange);
+            GameEvents.onEditorLoad.Remove(OnEditorLoad);
+            GameEvents.onEditorRestart.Remove(OnEditorRestart);
+            GameEvents.onEditorShipModified.Remove(OnEditorShipModified);
             GameEvents.onGUIAstronautComplexSpawn.Remove(OnACSpawn);
             GameEvents.onGUIAstronautComplexDespawn.Remove(OnACDespawn);
         }
 
+
+        // Game Event Hooks:
         protected void OnEditorScreenChange(EditorScreen screen) {
             if( screen == EditorScreen.Crew ){
                 sortBar.enabled = true;
@@ -86,19 +135,83 @@ namespace KerbalSorter.Hooks
                 sortBar.SetPos(baseX + anim.Evaluate(0f), baseY);
 
                 //sortBar.gameObject.GetComponent<Animation>().Play("flyin");
+
+                if( fixDefaultAssignment ){
+                    Utilities.FixDefaultVesselCrew(vesselCrew, availableCrew, sortBar);
+                    fixDefaultAssignment = false;
+                }
             } else {
                 sortBar.enabled = false;
+            }
+        }
+
+        protected void OnEditorLoad(ShipConstruct ship, CraftBrowser.LoadType type){
+            if( type == CraftBrowser.LoadType.Normal && loadBtnPressed ){
+                // Unfortunately, the crew roster isn't set up yet here, so we
+                // have to delay fixing the default assignment until either the
+                // user opens the crew assignment tab, or they launch the craft.
+                fixDefaultAssignment = true;
+                loadBtnPressed = false;
+            }
+        }
+
+        protected void OnEditorRestart(){
+            noParts = true;
+        }
+
+        protected void OnEditorShipModified(ShipConstruct ship){
+            if( ship.Count == 0 ){
+                noParts = true;
+            }
+            else if( noParts ){
+                // If they didn't have parts before, they might have placed a
+                // command capsule, which would be auto-filled. We'll need to
+                // correct this.
+                noParts = false;
+                fixDefaultAssignment = true;
             }
         }
 
         protected void OnACSpawn(){
             sortBar.enabled = false;
         }
-        protected void OnACDespawn()
-        {
+
+        protected void OnACDespawn() {
             // When we come out of the AC, we'll be in the Crew Select screen.
             sortBar.enabled = true;
         }
+
+
+        // Other UI Hooks:
+        protected void OnClearBtn(IUIObject btn) {
+            // At this point, the vessel crew list has been emptied back into
+            // the list of available crew.
+            sortBar.SortRoster();
+        }
+
+        protected void OnLoadBtn(IUIObject btn) {
+            // We need this to detect when a craft is being explicitly loaded
+            // by the user, rather than automatically loaded on entrance.
+            loadBtnPressed = true;
+        }
+
+        protected void OnResetBtn(IUIObject btn) {
+            // At this point, the list has been entirely rewritten, and kerbals
+            // have already been (temporarily) assigned to the ship.
+            Utilities.FixDefaultVesselCrew(vesselCrew, availableCrew, sortBar);
+        }
+
+        protected void OnAvailListValueChanged(IUIObject obj) {
+            // This is called when we click on a kerbal in the list, or when
+            // the red X next to a kerbal in the vessel crew is clicked.
+            // It is, unfortunately, not called when a kerbal is dragged into,
+            // out of, or within the list. The only way to detect that is to
+            // put an InputListener on each of those items, and that doesn't
+            // seem to give us a hook *after* the kerbal has been placed into
+            // the list, which means ATM we're SOL on really detecting drags.
+            sortBar.SortRoster();
+        }
+
 
 
         // ------- Animation handling -------

--- a/Hooks/EditorHook.cs
+++ b/Hooks/EditorHook.cs
@@ -4,8 +4,7 @@ using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
 
-namespace KerbalSorter.Hooks
-{
+namespace KerbalSorter.Hooks {
     [KSPAddon(KSPAddon.Startup.EditorAny, false)]
     class EditorHook : MonoBehaviour {
         SortingButtons sortBar;
@@ -14,9 +13,9 @@ namespace KerbalSorter.Hooks
         bool fixDefaultAssignment = false;
         bool loadBtnPressed = false;
         bool noParts = true;
-        
+
         protected void Start() {
-            try{
+            try {
                 // Game Event Hooks
                 GameEvents.onEditorScreenChange.Add(OnEditorScreenChange);
                 GameEvents.onEditorLoad.Add(OnEditorLoad);
@@ -91,17 +90,17 @@ namespace KerbalSorter.Hooks
                 // Add some extra hooks:
                 availableCrew.AddValueChangedDelegate(OnAvailListValueChanged);
                 Transform trans = UIManager.instance.transform.FindChild("panel_CrewAssignmentInEditor");
-                foreach( BTButton btn in trans.GetComponentsInChildren<BTButton>() ){
-                    if( btn.name == "button_reset" ){
+                foreach( BTButton btn in trans.GetComponentsInChildren<BTButton>() ) {
+                    if( btn.name == "button_reset" ) {
                         btn.AddValueChangedDelegate(OnResetBtn);
                     }
-                    else if( btn.name == "button_clear" ){
+                    else if( btn.name == "button_clear" ) {
                         btn.AddValueChangedDelegate(OnClearBtn);
                     }
                 }
                 trans = UIManager.instance.transform.FindChild("TopRightAnchor");
                 foreach( UIButton btn in trans.GetComponentsInChildren<UIButton>() ) {
-                    if( btn.name == "ButtonLoad" ){
+                    if( btn.name == "ButtonLoad" ) {
                         btn.AddValueChangedDelegate(OnLoadBtn);
                     }
                 }
@@ -110,7 +109,7 @@ namespace KerbalSorter.Hooks
                 loadBtnPressed = false;
                 noParts = true;
             }
-            catch (Exception e){
+            catch( Exception e ) {
                 Debug.LogError("KerbalSorter: Unexpected error in Editor Hook! " + e);
             }
         }
@@ -127,7 +126,7 @@ namespace KerbalSorter.Hooks
 
         // Game Event Hooks:
         protected void OnEditorScreenChange(EditorScreen screen) {
-            if( screen == EditorScreen.Crew ){
+            if( screen == EditorScreen.Crew ) {
                 sortBar.enabled = true;
                 playAnimation = true;
                 animProgress = 0f;
@@ -136,17 +135,18 @@ namespace KerbalSorter.Hooks
 
                 //sortBar.gameObject.GetComponent<Animation>().Play("flyin");
 
-                if( fixDefaultAssignment ){
+                if( fixDefaultAssignment ) {
                     Utilities.FixDefaultVesselCrew(vesselCrew, availableCrew, sortBar);
                     fixDefaultAssignment = false;
                 }
-            } else {
+            }
+            else {
                 sortBar.enabled = false;
             }
         }
 
-        protected void OnEditorLoad(ShipConstruct ship, CraftBrowser.LoadType type){
-            if( type == CraftBrowser.LoadType.Normal && loadBtnPressed ){
+        protected void OnEditorLoad(ShipConstruct ship, CraftBrowser.LoadType type) {
+            if( type == CraftBrowser.LoadType.Normal && loadBtnPressed ) {
                 // Unfortunately, the crew roster isn't set up yet here, so we
                 // have to delay fixing the default assignment until either the
                 // user opens the crew assignment tab, or they launch the craft.
@@ -155,15 +155,15 @@ namespace KerbalSorter.Hooks
             }
         }
 
-        protected void OnEditorRestart(){
+        protected void OnEditorRestart() {
             noParts = true;
         }
 
-        protected void OnEditorShipModified(ShipConstruct ship){
-            if( ship.Count == 0 ){
+        protected void OnEditorShipModified(ShipConstruct ship) {
+            if( ship.Count == 0 ) {
                 noParts = true;
             }
-            else if( noParts ){
+            else if( noParts ) {
                 // If they didn't have parts before, they might have placed a
                 // command capsule, which would be auto-filled. We'll need to
                 // correct this.
@@ -172,7 +172,7 @@ namespace KerbalSorter.Hooks
             }
         }
 
-        protected void OnACSpawn(){
+        protected void OnACSpawn() {
             sortBar.enabled = false;
         }
 
@@ -225,8 +225,8 @@ namespace KerbalSorter.Hooks
         float baseY;
 
         protected void Update() {
-            if( playAnimation ){
-                if( animProgress > animEndTime ){
+            if( playAnimation ) {
+                if( animProgress > animEndTime ) {
                     playAnimation = false;
                 }
                 float x = baseX + anim.Evaluate(animProgress);

--- a/Hooks/EditorHook.cs
+++ b/Hooks/EditorHook.cs
@@ -67,8 +67,10 @@ namespace KerbalSorter.Hooks {
                 float y = tabPos.y - 1;
 
                 // Set up button list:
-                SortButtonDef[] buttons = new SortButtonDef[]{ StandardButtonDefs.ByName,
-                    StandardButtonDefs.ByClass, StandardButtonDefs.ByLevel, StandardButtonDefs.ByGender
+                SortButtonDef[] buttons = new SortButtonDef[]{
+                    StandardButtonDefs.ByName, StandardButtonDefs.ByClass,
+                    StandardButtonDefs.ByLevel, StandardButtonDefs.ByGender,
+                    StandardButtonDefs.ByNumFlights
                 };
 
                 // Initialize the sort bar:

--- a/Hooks/EditorHook.cs
+++ b/Hooks/EditorHook.cs
@@ -110,48 +110,63 @@ namespace KerbalSorter.Hooks {
                 noParts = true;
             }
             catch( Exception e ) {
-                Debug.LogError("KerbalSorter: Unexpected error in Editor Hook! " + e);
+                Debug.LogError("KerbalSorter: Unexpected error in EditorHook: " + e);
             }
         }
 
         protected void OnDestroy() {
-            GameEvents.onEditorScreenChange.Remove(OnEditorScreenChange);
-            GameEvents.onEditorLoad.Remove(OnEditorLoad);
-            GameEvents.onEditorRestart.Remove(OnEditorRestart);
-            GameEvents.onEditorShipModified.Remove(OnEditorShipModified);
-            GameEvents.onGUIAstronautComplexSpawn.Remove(OnACSpawn);
-            GameEvents.onGUIAstronautComplexDespawn.Remove(OnACDespawn);
+            try {
+                GameEvents.onEditorScreenChange.Remove(OnEditorScreenChange);
+                GameEvents.onEditorLoad.Remove(OnEditorLoad);
+                GameEvents.onEditorRestart.Remove(OnEditorRestart);
+                GameEvents.onEditorShipModified.Remove(OnEditorShipModified);
+                GameEvents.onGUIAstronautComplexSpawn.Remove(OnACSpawn);
+                GameEvents.onGUIAstronautComplexDespawn.Remove(OnACDespawn);
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in EditorHook: " + e);
+            }
         }
 
 
         // Game Event Hooks:
         protected void OnEditorScreenChange(EditorScreen screen) {
-            if( screen == EditorScreen.Crew ) {
-                sortBar.enabled = true;
-                playAnimation = true;
-                animProgress = 0f;
-                // To ensure a smooth transition:
-                sortBar.SetPos(baseX + anim.Evaluate(0f), baseY);
+            try {
+                if( screen == EditorScreen.Crew ) {
+                    sortBar.enabled = true;
+                    playAnimation = true;
+                    animProgress = 0f;
+                    // To ensure a smooth transition:
+                    sortBar.SetPos(baseX + anim.Evaluate(0f), baseY);
 
-                //sortBar.gameObject.GetComponent<Animation>().Play("flyin");
+                    //sortBar.gameObject.GetComponent<Animation>().Play("flyin");
 
-                if( fixDefaultAssignment ) {
-                    Utilities.FixDefaultVesselCrew(vesselCrew, availableCrew, sortBar);
-                    fixDefaultAssignment = false;
+                    if( fixDefaultAssignment ) {
+                        Utilities.FixDefaultVesselCrew(vesselCrew, availableCrew, sortBar);
+                        fixDefaultAssignment = false;
+                    }
+                }
+                else {
+                    sortBar.enabled = false;
                 }
             }
-            else {
-                sortBar.enabled = false;
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in EditorHook: " + e);
             }
         }
 
         protected void OnEditorLoad(ShipConstruct ship, CraftBrowser.LoadType type) {
-            if( type == CraftBrowser.LoadType.Normal && loadBtnPressed ) {
-                // Unfortunately, the crew roster isn't set up yet here, so we
-                // have to delay fixing the default assignment until either the
-                // user opens the crew assignment tab, or they launch the craft.
-                fixDefaultAssignment = true;
-                loadBtnPressed = false;
+            try {
+                if( type == CraftBrowser.LoadType.Normal && loadBtnPressed ) {
+                    // Unfortunately, the crew roster isn't set up yet here, so we
+                    // have to delay fixing the default assignment until either the
+                    // user opens the crew assignment tab, or they launch the craft.
+                    fixDefaultAssignment = true;
+                    loadBtnPressed = false;
+                }
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in EditorHook: " + e);
             }
         }
 
@@ -160,6 +175,10 @@ namespace KerbalSorter.Hooks {
         }
 
         protected void OnEditorShipModified(ShipConstruct ship) {
+            if( ship == null ) {
+                Debug.LogError("KerbalSorter: Expected non-null ShipConstruct in OnEditorShipModified.");
+                return;
+            }
             if( ship.Count == 0 ) {
                 noParts = true;
             }
@@ -186,19 +205,34 @@ namespace KerbalSorter.Hooks {
         protected void OnClearBtn(IUIObject btn) {
             // At this point, the vessel crew list has been emptied back into
             // the list of available crew.
-            sortBar.SortRoster();
+            try {
+                sortBar.SortRoster();
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in EditorHook: " + e);
+            }
         }
 
         protected void OnLoadBtn(IUIObject btn) {
             // We need this to detect when a craft is being explicitly loaded
             // by the user, rather than automatically loaded on entrance.
-            loadBtnPressed = true;
+            try {
+                loadBtnPressed = true;
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in EditorHook: " + e);
+            }
         }
 
         protected void OnResetBtn(IUIObject btn) {
             // At this point, the list has been entirely rewritten, and kerbals
             // have already been (temporarily) assigned to the ship.
-            Utilities.FixDefaultVesselCrew(vesselCrew, availableCrew, sortBar);
+            try {
+                Utilities.FixDefaultVesselCrew(vesselCrew, availableCrew, sortBar);
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in EditorHook: " + e);
+            }
         }
 
         protected void OnAvailListValueChanged(IUIObject obj) {
@@ -209,7 +243,12 @@ namespace KerbalSorter.Hooks {
             // put an InputListener on each of those items, and that doesn't
             // seem to give us a hook *after* the kerbal has been placed into
             // the list, which means ATM we're SOL on really detecting drags.
-            sortBar.SortRoster();
+            try {
+                sortBar.SortRoster();
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in EditorHook: " + e);
+            }
         }
 
 
@@ -225,13 +264,18 @@ namespace KerbalSorter.Hooks {
         float baseY;
 
         protected void Update() {
-            if( playAnimation ) {
-                if( animProgress > animEndTime ) {
-                    playAnimation = false;
+            try {
+                if( playAnimation ) {
+                    if( animProgress > animEndTime ) {
+                        playAnimation = false;
+                    }
+                    float x = baseX + anim.Evaluate(animProgress);
+                    sortBar.SetPos(x, baseY);
+                    animProgress += Time.deltaTime;
                 }
-                float x = baseX + anim.Evaluate(animProgress);
-                sortBar.SetPos(x, baseY);
-                animProgress += Time.deltaTime;
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in EditorHook: " + e);
             }
         }
     }

--- a/Hooks/EditorHook.cs
+++ b/Hooks/EditorHook.cs
@@ -46,6 +46,7 @@ namespace KerbalSorter.Hooks
                 sortBar = gameObject.AddComponent<SortingButtons>();
                 sortBar.SetRoster(available);
                 sortBar.SetButtons(buttons);
+                sortBar.SetDefaultOrdering(StandardKerbalComparers.DefaultAvailable);
                 sortBar.SetPos(x, y);
                 sortBar.enabled = false;
             }

--- a/Hooks/EditorHook.cs
+++ b/Hooks/EditorHook.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace KerbalSorter.Hooks {
     [KSPAddon(KSPAddon.Startup.EditorAny, false)]
     class EditorHook : MonoBehaviour {
-        SortingButtons sortBar;
+        SortBar sortBar;
         UIScrollList availableCrew;
         UIScrollList vesselCrew;
         bool fixDefaultAssignment = false;
@@ -66,7 +66,7 @@ namespace KerbalSorter.Hooks {
                 };
 
                 // Initialize the sort bar:
-                sortBar = gameObject.AddComponent<SortingButtons>();
+                sortBar = gameObject.AddComponent<SortBar>();
                 sortBar.SetRoster(available);
                 sortBar.SetButtons(buttons);
                 sortBar.SetDefaultOrdering(StandardKerbalComparers.DefaultAvailable);

--- a/Hooks/EditorHook.cs
+++ b/Hooks/EditorHook.cs
@@ -49,6 +49,19 @@ namespace KerbalSorter.Hooks
                 sortBar.SetDefaultOrdering(StandardKerbalComparers.DefaultAvailable);
                 sortBar.SetPos(x, y);
                 sortBar.enabled = false;
+
+                // Create a fly-in animation for the sort bar.
+                baseX = x;
+                baseY = y;
+                float animBeginTime = 0.2f;
+                animEndTime = 0.5f;
+                anim = AnimationCurve.Linear(animBeginTime, -575f, animEndTime, 0f);
+
+                // This is what I would have *liked* to have done, but Unity decided this should do absolutely nothing.
+                /*AnimationCurve curve = AnimationCurve.Linear(0f, 0f, 10f, 100f);
+                AnimationClip clip = new AnimationClip();
+                clip.SetCurve("", typeof(Transform), "position.x", curve);
+                sortBar.gameObject.AddComponent<Animation>().AddClip(clip, "flyin");*/
             }
             catch (Exception e){
                 Debug.LogError("KerbalSorter: Unexpected error in Editor Hook! " + e);
@@ -62,8 +75,36 @@ namespace KerbalSorter.Hooks
         protected void OnEditorScreenChange(EditorScreen screen) {
             if( screen == EditorScreen.Crew ){
                 sortBar.enabled = true;
+                playAnimation = true;
+                animProgress = 0f;
+                // To ensure a smooth transition:
+                sortBar.SetPos(baseX + anim.Evaluate(0f), baseY);
+
+                //sortBar.gameObject.GetComponent<Animation>().Play("flyin");
             } else {
                 sortBar.enabled = false;
+            }
+        }
+
+
+        // ------- Animation handling -------
+        // Unity doesn't want to work with us on
+        // animation, so we have to do it manually.
+        AnimationCurve anim;
+        bool playAnimation = false;
+        float animProgress = 0f;
+        float animEndTime;
+        float baseX;
+        float baseY;
+
+        protected void Update() {
+            if( playAnimation ){
+                if( animProgress > animEndTime ){
+                    playAnimation = false;
+                }
+                float x = baseX + anim.Evaluate(animProgress);
+                sortBar.SetPos(x, baseY);
+                animProgress += Time.deltaTime;
             }
         }
     }

--- a/Hooks/LaunchWindowHook.cs
+++ b/Hooks/LaunchWindowHook.cs
@@ -58,8 +58,10 @@ namespace KerbalSorter.Hooks {
                 StockRoster available = new StockRoster(availableCrew);
 
                 // Set up button list:
-                SortButtonDef[] buttons = new SortButtonDef[]{ StandardButtonDefs.ByName,
-                    StandardButtonDefs.ByClass, StandardButtonDefs.ByLevel, StandardButtonDefs.ByGender
+                SortButtonDef[] buttons = new SortButtonDef[]{
+                    StandardButtonDefs.ByName, StandardButtonDefs.ByClass,
+                    StandardButtonDefs.ByLevel, StandardButtonDefs.ByGender,
+                    StandardButtonDefs.ByNumFlights
                 };
 
                 // Initialize the sort bar:

--- a/Hooks/LaunchWindowHook.cs
+++ b/Hooks/LaunchWindowHook.cs
@@ -29,6 +29,7 @@ namespace KerbalSorter.Hooks
                 }
                 UIScrollList[] lists = window.GetComponentsInChildren<UIScrollList>(true);
                 availableCrew = null;
+                vesselCrew = null;
                 foreach( UIScrollList list in lists ){
                     if (list.name == "scrolllist_avail")
                     {

--- a/Hooks/LaunchWindowHook.cs
+++ b/Hooks/LaunchWindowHook.cs
@@ -4,8 +4,7 @@ using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
 
-namespace KerbalSorter.Hooks
-{
+namespace KerbalSorter.Hooks {
     [KSPAddon(KSPAddon.Startup.SpaceCentre, false)]
     public class LaunchWindowHook : MonoBehaviour {
         SortingButtons sortBar;
@@ -14,7 +13,7 @@ namespace KerbalSorter.Hooks
         bool launchScreenUp = false;
 
         protected void Start() {
-            try{
+            try {
                 GameEvents.onGUILaunchScreenSpawn.Add(LaunchScreenSpawn);
                 GameEvents.onGUILaunchScreenDespawn.Add(LaunchScreenDespawn);
                 GameEvents.onGUILaunchScreenVesselSelected.Add(VesselSelect);
@@ -24,32 +23,30 @@ namespace KerbalSorter.Hooks
 
                 // Get the Roster and the vessel crew list:
                 VesselSpawnDialog window = UIManager.instance.gameObject.GetComponentsInChildren<VesselSpawnDialog>(true).FirstOrDefault();
-                if( window == null ){
+                if( window == null ) {
                     throw new Exception("Could not find Launch Window!");
                 }
                 UIScrollList[] lists = window.GetComponentsInChildren<UIScrollList>(true);
                 availableCrew = null;
                 vesselCrew = null;
-                foreach( UIScrollList list in lists ){
-                    if (list.name == "scrolllist_avail")
-                    {
+                foreach( UIScrollList list in lists ) {
+                    if( list.name == "scrolllist_avail" ) {
                         availableCrew = list;
-                        if( vesselCrew != null ){
+                        if( vesselCrew != null ) {
                             break;
                         }
                     }
-                    else if (list.name == "scrolllist_crew")
-                    {
+                    else if( list.name == "scrolllist_crew" ) {
                         vesselCrew = list;
-                        if( availableCrew != null ){
+                        if( availableCrew != null ) {
                             break;
                         }
                     }
                 }
-                if( availableCrew == null ){
+                if( availableCrew == null ) {
                     throw new Exception("Could not find Available Crew List!");
                 }
-                if( vesselCrew == null ){
+                if( vesselCrew == null ) {
                     throw new Exception("Could not find Vessel Crew List!");
                 }
                 StockRoster available = new StockRoster(availableCrew);
@@ -74,7 +71,8 @@ namespace KerbalSorter.Hooks
                 btn.AddValueChangedDelegate(OnResetBtn);
                 btn = anchorButtons.FindChild("button_clear").GetComponent<BTButton>();
                 btn.AddValueChangedDelegate(OnClearBtn);
-            } catch( Exception e ){
+            }
+            catch( Exception e ) {
                 Debug.LogError("KerbalSorter: Unexpected error in LaunchWindow Hook! " + e);
             }
         }
@@ -91,7 +89,7 @@ namespace KerbalSorter.Hooks
         protected void LaunchScreenSpawn(GameEvents.VesselSpawnInfo blah) {
             Transform tab_crewavail = availableCrew.transform.parent.Find("tab_crewavail");
             BTButton tab = tab_crewavail.GetComponent<BTButton>();
-            
+
             // Set position:
             Vector3 tabPos = Utilities.GetPosition(tab_crewavail);
             float x = tabPos.x + tab.width + 5;
@@ -116,7 +114,7 @@ namespace KerbalSorter.Hooks
         protected void OnACSpawn() {
             sortBar.enabled = false;
         }
-        
+
         protected void OnACDespawn() {
             // When we come out of the AC, we may or may not be on the launch screen.
             sortBar.enabled = launchScreenUp;

--- a/Hooks/LaunchWindowHook.cs
+++ b/Hooks/LaunchWindowHook.cs
@@ -73,31 +73,41 @@ namespace KerbalSorter.Hooks {
                 btn.AddValueChangedDelegate(OnClearBtn);
             }
             catch( Exception e ) {
-                Debug.LogError("KerbalSorter: Unexpected error in LaunchWindow Hook! " + e);
+                Debug.LogError("KerbalSorter: Unexpected error in LaunchWindowHook: " + e);
             }
         }
 
         protected void OnDestroy() {
-            GameEvents.onGUILaunchScreenSpawn.Remove(LaunchScreenSpawn);
-            GameEvents.onGUILaunchScreenDespawn.Remove(LaunchScreenDespawn);
-            GameEvents.onGUILaunchScreenVesselSelected.Remove(VesselSelect);
-            GameEvents.onGUIAstronautComplexSpawn.Remove(OnACSpawn);
-            GameEvents.onGUIAstronautComplexDespawn.Remove(OnACDespawn);
+            try {
+                GameEvents.onGUILaunchScreenSpawn.Remove(LaunchScreenSpawn);
+                GameEvents.onGUILaunchScreenDespawn.Remove(LaunchScreenDespawn);
+                GameEvents.onGUILaunchScreenVesselSelected.Remove(VesselSelect);
+                GameEvents.onGUIAstronautComplexSpawn.Remove(OnACSpawn);
+                GameEvents.onGUIAstronautComplexDespawn.Remove(OnACDespawn);
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in LaunchWindowHook: " + e);
+            }
         }
 
         // Game Event Hooks:
         protected void LaunchScreenSpawn(GameEvents.VesselSpawnInfo blah) {
-            Transform tab_crewavail = availableCrew.transform.parent.Find("tab_crewavail");
-            BTButton tab = tab_crewavail.GetComponent<BTButton>();
+            try {
+                Transform tab_crewavail = availableCrew.transform.parent.Find("tab_crewavail");
+                BTButton tab = tab_crewavail.GetComponent<BTButton>();
 
-            // Set position:
-            Vector3 tabPos = Utilities.GetPosition(tab_crewavail);
-            float x = tabPos.x + tab.width + 5;
-            float y = tabPos.y - 1;
-            sortBar.SetPos(x, y);
+                // Set position:
+                Vector3 tabPos = Utilities.GetPosition(tab_crewavail);
+                float x = tabPos.x + tab.width + 5;
+                float y = tabPos.y - 1;
+                sortBar.SetPos(x, y);
 
-            sortBar.enabled = true;
-            launchScreenUp = true;
+                sortBar.enabled = true;
+                launchScreenUp = true;
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in LaunchWindowHook: " + e);
+            }
         }
 
         protected void LaunchScreenDespawn() {
@@ -108,7 +118,12 @@ namespace KerbalSorter.Hooks {
         protected void VesselSelect(ShipTemplate ship) {
             // At this point, the list has been entirely rewritten, and kerbals
             // have already been (temporarily) assigned to the ship.
-            Utilities.FixDefaultVesselCrew(vesselCrew, availableCrew, sortBar);
+            try {
+                Utilities.FixDefaultVesselCrew(vesselCrew, availableCrew, sortBar);
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in LaunchWindowHook: " + e);
+            }
         }
 
         protected void OnACSpawn() {
@@ -125,13 +140,23 @@ namespace KerbalSorter.Hooks {
         protected void OnResetBtn(IUIObject btn) {
             // At this point, the list has been entirely rewritten, and kerbals
             // have already been (temporarily) assigned to the ship.
-            Utilities.FixDefaultVesselCrew(vesselCrew, availableCrew, sortBar);
+            try {
+                Utilities.FixDefaultVesselCrew(vesselCrew, availableCrew, sortBar);
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in LaunchWindowHook: " + e);
+            }
         }
 
         protected void OnClearBtn(IUIObject btn) {
             // At this point, the vessel crew list has been emptied back into
             // the list of available crew.
-            sortBar.SortRoster();
+            try {
+                sortBar.SortRoster();
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in LaunchWindowHook: " + e);
+            }
         }
 
         protected void OnAvailListValueChanged(IUIObject obj) {
@@ -142,7 +167,12 @@ namespace KerbalSorter.Hooks {
             // put an InputListener on each of those items, and that doesn't
             // seem to give us a hook *after* the kerbal has been placed into
             // the list, which means ATM we're SOL on really detecting drags.
-            sortBar.SortRoster();
+            try {
+                sortBar.SortRoster();
+            }
+            catch( Exception e ) {
+                Debug.LogError("KerbalSorter: Unexpected error in LaunchWindowHook: " + e);
+            }
         }
 
 

--- a/Hooks/LaunchWindowHook.cs
+++ b/Hooks/LaunchWindowHook.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 namespace KerbalSorter.Hooks {
     [KSPAddon(KSPAddon.Startup.SpaceCentre, false)]
     public class LaunchWindowHook : MonoBehaviour {
-        SortingButtons sortBar;
+        SortBar sortBar;
         UIScrollList availableCrew;
         UIScrollList vesselCrew;
         bool launchScreenUp = false;
@@ -57,7 +57,7 @@ namespace KerbalSorter.Hooks {
                 };
 
                 // Initialize the sort bar:
-                sortBar = gameObject.AddComponent<SortingButtons>();
+                sortBar = gameObject.AddComponent<SortBar>();
                 sortBar.SetRoster(available);
                 sortBar.SetButtons(buttons);
                 sortBar.SetDefaultOrdering(StandardKerbalComparers.DefaultAvailable);

--- a/Hooks/LaunchWindowHook.cs
+++ b/Hooks/LaunchWindowHook.cs
@@ -10,11 +10,16 @@ namespace KerbalSorter.Hooks
     public class LaunchWindowHook : MonoBehaviour {
         SortingButtons sortBar;
         UIScrollList availableCrew;
+        bool launchScreenUp = false;
+
         protected void Start() {
             try{
                 GameEvents.onGUILaunchScreenSpawn.Add(LaunchScreenSpawn);
                 GameEvents.onGUILaunchScreenDespawn.Add(LaunchScreenDespawn);
                 //GameEvents.onGUILaunchScreenVesselSelected.Add(VesselSelect);
+                // We actually do need these:
+                GameEvents.onGUIAstronautComplexSpawn.Add(OnACSpawn);
+                GameEvents.onGUIAstronautComplexDespawn.Add(OnACDespawn);
 
                 // Get the Roster:
                 VesselSpawnDialog window = UIManager.instance.gameObject.GetComponentsInChildren<VesselSpawnDialog>(true).FirstOrDefault();
@@ -55,6 +60,8 @@ namespace KerbalSorter.Hooks
             GameEvents.onGUILaunchScreenSpawn.Remove(LaunchScreenSpawn);
             GameEvents.onGUILaunchScreenDespawn.Remove(LaunchScreenDespawn);
             //GameEvents.onGUILaunchScreenVesselSelected.Remove(VesselSelect);
+            GameEvents.onGUIAstronautComplexSpawn.Remove(OnACSpawn);
+            GameEvents.onGUIAstronautComplexDespawn.Remove(OnACDespawn);
         }
 
 
@@ -69,11 +76,24 @@ namespace KerbalSorter.Hooks
             sortBar.SetPos(x, y);
 
             sortBar.enabled = true;
+            launchScreenUp = true;
         }
 
         protected void LaunchScreenDespawn() {
             //Debug.Log("KerbalSorter: Launch Screen Despawned!");
             sortBar.enabled = false;
+            launchScreenUp = false;
+        }
+
+
+        protected void OnACSpawn()
+        {
+            sortBar.enabled = false;
+        }
+        protected void OnACDespawn()
+        {
+            // When we come out of the AC, we may or may not be on the launch screen.
+            sortBar.enabled = launchScreenUp;
         }
     }
 }

--- a/Hooks/LaunchWindowHook.cs
+++ b/Hooks/LaunchWindowHook.cs
@@ -5,6 +5,9 @@ using System.Linq;
 using System.Collections.Generic;
 
 namespace KerbalSorter.Hooks {
+    /// <summary>
+    /// A hook for the Launch Windows. Started up whenever the Space Centre is loaded.
+    /// </summary>
     [KSPAddon(KSPAddon.Startup.SpaceCentre, false)]
     public class LaunchWindowHook : MonoBehaviour {
         SortBar sortBar;
@@ -12,6 +15,9 @@ namespace KerbalSorter.Hooks {
         UIScrollList vesselCrew;
         bool launchScreenUp = false;
 
+        /// <summary>
+        /// Set up the Sort Bar for the Launch Windows. (Callback)
+        /// </summary>
         protected void Start() {
             try {
                 GameEvents.onGUILaunchScreenSpawn.Add(LaunchScreenSpawn);
@@ -77,6 +83,9 @@ namespace KerbalSorter.Hooks {
             }
         }
 
+        /// <summary>
+        /// Remove GameEvent hooks when this hook is unloaded. (Callback)
+        /// </summary>
         protected void OnDestroy() {
             try {
                 GameEvents.onGUILaunchScreenSpawn.Remove(LaunchScreenSpawn);
@@ -90,7 +99,14 @@ namespace KerbalSorter.Hooks {
             }
         }
 
-        // Game Event Hooks:
+        // ====================================================================
+        //  Game Event Hooks
+        // ====================================================================
+
+        /// <summary>
+        /// Set the Sort Bar position and enable it on Launch Window spawn. (Callback)
+        /// </summary>
+        /// <param name="blah">?</param>
         protected void LaunchScreenSpawn(GameEvents.VesselSpawnInfo blah) {
             try {
                 Transform tab_crewavail = availableCrew.transform.parent.Find("tab_crewavail");
@@ -110,14 +126,21 @@ namespace KerbalSorter.Hooks {
             }
         }
 
+        /// <summary>
+        /// Disable the Sort Bar on Astronaut Complex despawn. (Callback)
+        /// </summary>
         protected void LaunchScreenDespawn() {
             sortBar.enabled = false;
             launchScreenUp = false;
         }
 
+        /// <summary>
+        /// Fix the default vessel crew listing when a vessel is selected. (Callback)
+        /// </summary>
+        /// This is called after the list has been entirely rewritten, and
+        /// kerbals have already been (temporarily) assigned to the ship.
+        /// <param name="ship">The vessel selected</param>
         protected void VesselSelect(ShipTemplate ship) {
-            // At this point, the list has been entirely rewritten, and kerbals
-            // have already been (temporarily) assigned to the ship.
             try {
                 Utilities.FixDefaultVesselCrew(vesselCrew, availableCrew, sortBar);
             }
@@ -126,20 +149,33 @@ namespace KerbalSorter.Hooks {
             }
         }
 
+        /// <summary>
+        /// Disable the Sort Bar when we jump to the Astronaut Complex. (Callback)
+        /// </summary>
         protected void OnACSpawn() {
             sortBar.enabled = false;
         }
 
+        /// <summary>
+        /// Re-enable the Sort Bar when we leave the Astronaut Complex. (Callback)
+        /// </summary>
         protected void OnACDespawn() {
             // When we come out of the AC, we may or may not be on the launch screen.
             sortBar.enabled = launchScreenUp;
         }
 
 
-        // Other UI Hooks:
+        // ====================================================================
+        //  Other UI Hooks
+        // ====================================================================
+
+        /// <summary>
+        /// Fix the default vessel crew listing when the Reset button is pressed. (Callback)
+        /// </summary>
+        /// This is called after the list has been entirely rewritten, and
+        /// kerbals have already been (temporarily) assigned to the ship.
+        /// <param name="btn"></param>
         protected void OnResetBtn(IUIObject btn) {
-            // At this point, the list has been entirely rewritten, and kerbals
-            // have already been (temporarily) assigned to the ship.
             try {
                 Utilities.FixDefaultVesselCrew(vesselCrew, availableCrew, sortBar);
             }
@@ -148,9 +184,13 @@ namespace KerbalSorter.Hooks {
             }
         }
 
+        /// <summary>
+        /// Re-sort the available list when we clear the vessel crew. (Callback)
+        /// </summary>
+        /// This is called after the vessel crew list has been emptied after
+        /// pressing the Clear button.
+        /// <param name="btn"></param>
         protected void OnClearBtn(IUIObject btn) {
-            // At this point, the vessel crew list has been emptied back into
-            // the list of available crew.
             try {
                 sortBar.SortRoster();
             }
@@ -159,14 +199,18 @@ namespace KerbalSorter.Hooks {
             }
         }
 
+        /// <summary>
+        /// Re-sort the list whenever it changes. (Callback)
+        /// </summary>
+        /// This is called when we click on a kerbal in the list, or when
+        /// the red X next to a kerbal in the vessel crew is clicked.
+        /// It is, unfortunately, not called when a kerbal is dragged into,
+        /// out of, or within the list. The only way to detect that is to
+        /// put an InputListener on each of those items, and that doesn't
+        /// seem to give us a hook *after* the kerbal has been placed into
+        /// the list, which means ATM we're SOL on really detecting drags.
+        /// <param name="obj"></param>
         protected void OnAvailListValueChanged(IUIObject obj) {
-            // This is called when we click on a kerbal in the list, or when
-            // the red X next to a kerbal in the vessel crew is clicked.
-            // It is, unfortunately, not called when a kerbal is dragged into,
-            // out of, or within the list. The only way to detect that is to
-            // put an InputListener on each of those items, and that doesn't
-            // seem to give us a hook *after* the kerbal has been placed into
-            // the list, which means ATM we're SOL on really detecting drags.
             try {
                 sortBar.SortRoster();
             }

--- a/Hooks/LaunchWindowHook.cs
+++ b/Hooks/LaunchWindowHook.cs
@@ -44,6 +44,7 @@ namespace KerbalSorter.Hooks
                 sortBar = gameObject.AddComponent<SortingButtons>();
                 sortBar.SetRoster(available);
                 sortBar.SetButtons(buttons);
+                sortBar.SetDefaultOrdering(StandardKerbalComparers.DefaultAvailable);
                 sortBar.enabled = false;
             } catch( Exception e ){
                 Debug.LogError("KerbalSorter: Unexpected error in LaunchWindow Hook! " + e);

--- a/Hooks/StockRoster.cs
+++ b/Hooks/StockRoster.cs
@@ -5,6 +5,9 @@ using System.Linq;
 using System.Collections.Generic;
 
 namespace KerbalSorter.Hooks {
+    /// <summary>
+    /// Wrapper object for the stock kerbal roster for use with SortBar.
+    /// </summary>
     class StockRoster : Roster<IUIListObject> {
         private UIScrollList crew;
 
@@ -12,22 +15,45 @@ namespace KerbalSorter.Hooks {
             this.crew = crew;
         }
 
+        /// <summary>
+        /// Number of kerbals in the list.
+        /// </summary>
         public int Count {
             get { return crew.Count; }
         }
 
+        /// <summary>
+        /// Gets the IUIListObject representing the kerbal at the given index.
+        /// </summary>
+        /// Use GetKerbal() to retrieve the ProtoCrewMember in the returned item.
+        /// <param name="index"></param>
+        /// <returns></returns>
         public IUIListObject GetItem(int index) {
             return crew.GetItem(index);
         }
 
+        /// <summary>
+        /// Removes the kerbal at the given index.
+        /// </summary>
+        /// <param name="index"></param>
         public void RemoveItem(int index) {
             crew.RemoveItem(index, false);
         }
 
+        /// <summary>
+        /// Inserts a kerbal at the given index.
+        /// </summary>
+        /// <param name="item">The IUIListObject representing the kerbal</param>
+        /// <param name="index"></param>
         public void InsertItem(IUIListObject item, int index) {
             crew.InsertItem(item, index);
         }
 
+        /// <summary>
+        /// Retrieves a kerbal from its IUIListObject wrapper.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
         public ProtoCrewMember GetKerbal(IUIListObject item) {
             return item.gameObject.GetComponent<CrewItemContainer>().GetCrewRef();
         }

--- a/Hooks/StockRoster.cs
+++ b/Hooks/StockRoster.cs
@@ -4,17 +4,16 @@ using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
 
-namespace KerbalSorter.Hooks
-{
-    class StockRoster :  Roster<IUIListObject> {
+namespace KerbalSorter.Hooks {
+    class StockRoster : Roster<IUIListObject> {
         private UIScrollList crew;
 
         public StockRoster(UIScrollList crew) {
             this.crew = crew;
         }
 
-        public int Count{
-            get{ return crew.Count; }
+        public int Count {
+            get { return crew.Count; }
         }
 
         public IUIListObject GetItem(int index) {

--- a/Hooks/Utilities.cs
+++ b/Hooks/Utilities.cs
@@ -4,14 +4,13 @@ using UnityEngine;
 using System.Linq;
 using System.Collections.Generic;
 
-namespace KerbalSorter.Hooks
-{
+namespace KerbalSorter.Hooks {
     static class Utilities {
         public static Vector3 GetPosition(Transform trans) {
             var uiCams = UIManager.instance.uiCameras;
             EZCameraSettings uiCam = null;
-            for( int i = 0; i < uiCams.Length; i++ ){
-                if( (uiCams[i].mask & (1 << trans.gameObject.layer)) != 0 ){
+            for( int i = 0; i < uiCams.Length; i++ ) {
+                if( (uiCams[i].mask & (1 << trans.gameObject.layer)) != 0 ) {
                     uiCam = uiCams[i];
                     break;
                 }
@@ -42,28 +41,28 @@ namespace KerbalSorter.Hooks
                     }
                     string debug = "KerbalSorter: " + cont.GetName() + " found in the vessel's crew.";
                     debug += " In Vessel ";
-                    if( cont.GetCrewRef() != null && cont.GetCrewRef().KerbalRef != null && cont.GetCrewRef().KerbalRef.InVessel != null ){
+                    if( cont.GetCrewRef() != null && cont.GetCrewRef().KerbalRef != null && cont.GetCrewRef().KerbalRef.InVessel != null ) {
                         debug += cont.GetCrewRef().KerbalRef.InVessel.name;
                     }
                     else {
                         debug += "???";
                     }
                     debug += " In Part ";
-                    if( cont.GetCrewRef() != null && cont.GetCrewRef().KerbalRef != null && cont.GetCrewRef().KerbalRef.InPart != null ){
+                    if( cont.GetCrewRef() != null && cont.GetCrewRef().KerbalRef != null && cont.GetCrewRef().KerbalRef.InPart != null ) {
                         debug += cont.GetCrewRef().KerbalRef.InPart.name;
                     }
                     else {
                         debug += "???";
                     }
                     debug += " Seat ";
-                    if( cont.GetCrewRef()!=null && cont.GetCrewRef().seat!=null ){
+                    if( cont.GetCrewRef() != null && cont.GetCrewRef().seat != null ) {
                         debug += cont.GetCrewRef().seat.name;
                     }
                     else {
                         debug += "???";
                     }
                     debug += " Idx ";
-                    if( cont.GetCrewRef()!=null ){
+                    if( cont.GetCrewRef() != null ) {
                         debug += cont.GetCrewRef().seatIdx;
                     }
                     else {
@@ -82,7 +81,7 @@ namespace KerbalSorter.Hooks
             sortBar.SortRoster();
 
             // Add input listeners to each of the kerbals so we can tell when they're dragged
-            /*for( int i = 0; i < availableCrew.Count; i++ ){
+            /*for( int i = 0; i < availableCrew.Count; i++ ) {
                 availableCrew.GetItem(i).AddInputDelegate(OnInput);
             }*/
 
@@ -99,15 +98,15 @@ namespace KerbalSorter.Hooks
 
         public static List<string> EnumerateTransformDescendents(Transform trans) {
             List<string> children = new List<string>();
-            if( trans == null ){
+            if( trans == null ) {
                 return children;
             }
 
-            foreach(Transform child in trans){
+            foreach( Transform child in trans ) {
                 string name = child.name;
                 children.Add(name);
                 List<string> grandchildren = EnumerateTransformDescendents(child);
-                foreach( string grandchild in grandchildren ){
+                foreach( string grandchild in grandchildren ) {
                     children.Add(name + "/" + grandchild);
                 }
             }

--- a/Hooks/Utilities.cs
+++ b/Hooks/Utilities.cs
@@ -21,7 +21,7 @@ namespace KerbalSorter.Hooks {
         }
 
         // Prequisites: The vessel has only one cabin with crew in it.
-        public static void FixDefaultVesselCrew(UIScrollList vesselCrew, UIScrollList availableCrew, SortingButtons sortBar) {
+        public static void FixDefaultVesselCrew(UIScrollList vesselCrew, UIScrollList availableCrew, SortBar sortBar) {
             // WARNING: Apparently this causes NullReferenceExceptions when used. I have yet to determine exactly why.
             // Until I can fix the NullReferenceExceptions, this will be commented out.
 

--- a/Hooks/Utilities.cs
+++ b/Hooks/Utilities.cs
@@ -5,7 +5,15 @@ using System.Linq;
 using System.Collections.Generic;
 
 namespace KerbalSorter.Hooks {
+    /// <summary>
+    /// A static class with utility functions.
+    /// </summary>
     static class Utilities {
+        /// <summary>
+        /// Gets the screen position of a particular UI object whose transformation is given.
+        /// </summary>
+        /// <param name="trans">The transformation of the UI object to locate</param>
+        /// <returns>The screen position of the UI object</returns>
         public static Vector3 GetPosition(Transform trans) {
             var uiCams = UIManager.instance.uiCameras;
             EZCameraSettings uiCam = null;
@@ -20,7 +28,13 @@ namespace KerbalSorter.Hooks {
             return screenPos;
         }
 
-        // Prequisites: The vessel has only one cabin with crew in it.
+        /// <summary>
+        /// Replaces a vessel's default crew with the first few kerbals available according to the given sortbar's settings.
+        /// </summary>
+        /// Prequisites: The vessel has only one cabin with crew in it.
+        /// <param name="vesselCrew">List containing the vessel's crew</param>
+        /// <param name="availableCrew">List containing the available crew</param>
+        /// <param name="sortBar">The sortbar whose criterion to sort by</param>
         public static void FixDefaultVesselCrew(UIScrollList vesselCrew, UIScrollList availableCrew, SortBar sortBar) {
             // WARNING: Apparently this causes NullReferenceExceptions when used. I have yet to determine exactly why.
             // Until I can fix the NullReferenceExceptions, this will be commented out.
@@ -96,6 +110,12 @@ namespace KerbalSorter.Hooks {
         }
 
 
+        /// <summary>
+        /// Returns a list of all transform objects under the given transform object.
+        /// </summary>
+        /// This is intended for debug and development purposes only.
+        /// <param name="trans">The transform whose descendents to enumerate</param>
+        /// <returns>A list of all descendents of the given transform</returns>
         public static List<string> EnumerateTransformDescendents(Transform trans) {
             List<string> children = new List<string>();
             if( trans == null ) {

--- a/Hooks/Utilities.cs
+++ b/Hooks/Utilities.cs
@@ -109,6 +109,74 @@ namespace KerbalSorter.Hooks {
             }*/
         }
 
+        /// <summary>
+        /// Adds a component to given Game Object that listens for it to be enabled.
+        /// </summary>
+        /// <param name="obj">The Game Object to listen to</param>
+        /// <param name="callback">The function to call when enabled</param>
+        /// <param name="skipFirstTime">Skip the first enable?</param>
+        public static void AddOnEnableListener(GameObject obj, Callback callback, bool skipFirstTime = false) {
+            OnEnableListener listener = obj.AddComponent<OnEnableListener>();
+            listener.Callback = callback;
+            listener.SkipFirstTime = skipFirstTime;
+        }
+
+        /// <summary>
+        /// Adds a component to given Game Object that listens for it to be disabled.
+        /// </summary>
+        /// <param name="obj">The Game Object to listen to</param>
+        /// <param name="callback">The function to call when disabled</param>
+        /// <param name="skipFirstTime">Skip the first disable?</param>
+        public static void AddOnDisableListener(GameObject obj, Callback callback, bool skipFirstTime = false) {
+            OnDisableListener listener = obj.AddComponent<OnDisableListener>();
+            listener.Callback = callback;
+            listener.SkipFirstTime = skipFirstTime;
+        }
+
+        /// <summary>
+        /// A hook into any component's OnEnable event.
+        /// </summary>
+        /// Use: Assign, as a component, to the component you want to listen to.
+        public class OnEnableListener : MonoBehaviour {
+            public Callback Callback;
+            public bool SkipFirstTime = false;
+            private bool _doneFirstTime = false;
+            protected void OnEnable() {
+                try {
+                    if( SkipFirstTime && !_doneFirstTime ) {
+                        _doneFirstTime = true;
+                        return;
+                    }
+                    Callback();
+                }
+                catch( Exception e ) {
+                    Debug.LogError("KerbalSorter: Unexpected error in OnEnableListener: " + e);
+                }
+            }
+        }
+
+        /// <summary>
+        /// A hook into any component's OnDisable event.
+        /// </summary>
+        /// Use: Assign, as a component, to the component you want to listen to.
+        public class OnDisableListener : MonoBehaviour {
+            public Callback Callback;
+            public bool SkipFirstTime = false;
+            private bool _doneFirstTime = false;
+            protected void OnDisable() {
+                try {
+                    if( SkipFirstTime && !_doneFirstTime ) {
+                        _doneFirstTime = true;
+                        return;
+                    }
+                    Callback();
+                }
+                catch( Exception e ) {
+                    Debug.LogError("KerbalSorter: Unexpected error in OnDisableListener: " + e);
+                }
+            }
+        }
+
 
         /// <summary>
         /// Returns a list of all transform objects under the given transform object.

--- a/Hooks/Utilities.cs
+++ b/Hooks/Utilities.cs
@@ -23,8 +23,11 @@ namespace KerbalSorter.Hooks
 
         // Prequisites: The vessel has only one cabin with crew in it.
         public static void FixDefaultVesselCrew(UIScrollList vesselCrew, UIScrollList availableCrew, SortingButtons sortBar) {
+            // WARNING: Apparently this causes NullReferenceExceptions when used. I have yet to determine exactly why.
+            // Until I can fix the NullReferenceExceptions, this will be commented out.
+
             // Find the one cabin with crew in it:
-            int numCrew = 0;
+            /*int numCrew = 0;
             int crewLoc = -1;
             for( int i = 0; i < vesselCrew.Count; i++ ) {
                 IUIListObject obj = vesselCrew.GetItem(i);
@@ -37,14 +40,43 @@ namespace KerbalSorter.Hooks
                     if( crewLoc < 0 ) {
                         crewLoc = i;
                     }
-                    Debug.Log("KerbalSorter: " + cont.GetName() + " found in the vessel's crew.");
+                    string debug = "KerbalSorter: " + cont.GetName() + " found in the vessel's crew.";
+                    debug += " In Vessel ";
+                    if( cont.GetCrewRef() != null && cont.GetCrewRef().KerbalRef != null && cont.GetCrewRef().KerbalRef.InVessel != null ){
+                        debug += cont.GetCrewRef().KerbalRef.InVessel.name;
+                    }
+                    else {
+                        debug += "???";
+                    }
+                    debug += " In Part ";
+                    if( cont.GetCrewRef() != null && cont.GetCrewRef().KerbalRef != null && cont.GetCrewRef().KerbalRef.InPart != null ){
+                        debug += cont.GetCrewRef().KerbalRef.InPart.name;
+                    }
+                    else {
+                        debug += "???";
+                    }
+                    debug += " Seat ";
+                    if( cont.GetCrewRef()!=null && cont.GetCrewRef().seat!=null ){
+                        debug += cont.GetCrewRef().seat.name;
+                    }
+                    else {
+                        debug += "???";
+                    }
+                    debug += " Idx ";
+                    if( cont.GetCrewRef()!=null ){
+                        debug += cont.GetCrewRef().seatIdx;
+                    }
+                    else {
+                        debug += "?";
+                    }
+                    Debug.Log(debug);
                     cont.SetButton(CrewItemContainer.ButtonTypes.V);
                     vesselCrew.RemoveItem(i, false);
                     availableCrew.AddItem(obj);
                     numCrew++;
                     i--; // Don't accidentally skip something!
                 }
-            }
+            }*/
 
             // Re-sort the kerbals
             sortBar.SortRoster();
@@ -55,13 +87,13 @@ namespace KerbalSorter.Hooks
             }*/
 
             // Place the appropriate number of kerbals back into the crew roster
-            for( int i = 0; i < numCrew; i++ ) {
+            /*for( int i = 0; i < numCrew; i++ ) {
                 IUIListObject obj = availableCrew.GetItem(0);
                 availableCrew.RemoveItem(0, false);
                 vesselCrew.InsertItem(obj, crewLoc + i);
 
                 obj.gameObject.GetComponent<CrewItemContainer>().SetButton(CrewItemContainer.ButtonTypes.X);
-            }
+            }*/
         }
 
 

--- a/KerbalSorter.csproj
+++ b/KerbalSorter.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
       <HintPath>lib\Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -43,6 +44,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
       <HintPath>lib\UnityEngine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/KerbalSorter.csproj
+++ b/KerbalSorter.csproj
@@ -55,6 +55,9 @@
     <Compile Include="SortBar.cs" />
     <Compile Include="SortingInterface.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/KerbalSorter.csproj
+++ b/KerbalSorter.csproj
@@ -54,7 +54,7 @@
     <Compile Include="Hooks\StockRoster.cs" />
     <Compile Include="Hooks\Utilities.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SortingButtons.cs" />
+    <Compile Include="SortBar.cs" />
     <Compile Include="SortingInterface.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/KerbalSorter.csproj
+++ b/KerbalSorter.csproj
@@ -32,8 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\KSP Test Install\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>lib\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -43,8 +42,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\KSP Test Install\KSP_Data\Managed\UnityEngine.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>lib\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -18,16 +18,15 @@ If you have lots of kerbals, or are simply very organized, this is the mod for y
 ## To-Do
 
 * Add sorting by number of flights.
-* Re-sort Editor list when it changes.
 * Determine original order for assigned kerbals.
 * Add tooltips.
+* Figure out how to change default crew auto-assignment.
 
 
 ## Bugs
 
 These are the known bugs at the moment. Please file an issue if you find another one!
-* In the Editor, when removing a kerbal from a vehicle's crew roster, the kerbal is not sorted back into the available list; instead they're just put at the top.
-* In the Launch Window, when dragging and dropping a kerbal into the list of available crew, the kerbal is not sorted back into the available list. I seem to have no way to detect when this is done, nor any way to disable it.
+* In the Launch Windows and Editors, when dragging and dropping a kerbal into the list of available crew, the kerbal is not sorted back into the available list. I seem to have no way to detect when this is done, nor any way to disable it. If you drag and drop your kerbals, you can click on one of the kerbals in the available list to re-sort them.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ If you have lots of kerbals, or are simply very organized, this is the mod for y
 * Determine original order for assigned kerbals.
 * Add tooltips.
 * Figure out how to change default crew auto-assignment.
+* Add fly-in and fly-out animations for the sorting buttons on expansion and collapse?
 
 
 ## Bugs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KerbalSorter 0.4 (In Progress)
+# KerbalSorter 0.4
 A mod for Kerbal Space Program that allows players to sort their crew rosters.
 
 This mod adds a small toolbar to every crew roster in the game outside of flight mode for sorting your kerbals! Currently supported sorting criterion are:
@@ -7,8 +7,12 @@ This mod adds a small toolbar to every crew roster in the game outside of flight
 * Class
 * Level
 * Gender
+* Number of Flights
 
 If you have lots of kerbals, or are simply very organized, this is the mod for you!
+
+See also:  
+Development thread: http://forum.kerbalspaceprogram.com/threads/124612
 
 ## Future Plans
 

--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ This project requires Visual Studio 2012 or greater. It should be compatible wit
 
 The code in this repository is licensed under the BSD 3-Clause license. Please see the LICENSE file included in this repo and in every release for the full text.
 
-Three icons used in this mod (the wrench, steering wheel, and vial, as used in the sorting-by-class button) were taken from game-icons.net, and are licensed by them under the Creative Commons 3.0 License. I did not modify them in any way, except to display them on buttons in the game. All other icons were made by me (Jon Dahm) and are public domain.
+Four icons used in this mod (the wrench, steering wheel, and vial, as used in the sorting-by-class button, and the rocket in the sorting-by-num-flights button) were taken from game-icons.net, and are licensed by them under the Creative Commons 3.0 License. With the exception of the rocket, I did not modify them in any way, except to display them on buttons in the game. The rocket was modified from its original format to remove an exhaust effect and to rotate the ship, as well as to add arrows. All other icons were made by me (Jon Dahm) and are public domain.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KerbalSorter 0.3
+# KerbalSorter 0.4 (In Progress)
 A mod for Kerbal Space Program that allows players to sort their crew rosters.
 
 This mod adds a small toolbar to every crew roster in the game outside of flight mode for sorting your kerbals! Currently supported sorting criterion are:
@@ -17,16 +17,17 @@ If you have lots of kerbals, or are simply very organized, this is the mod for y
 
 ## To-Do
 
-* Add sorting assigned and KIA crew in the Astronaut Complex
-* Add sorting by number of flights
-* Add fly-in animation to editor sort bar to match the Crew tab fly-in animation.
-* Re-sort lists when they change.
-* Perhaps find a way to restore original order when sorting options are cancelled.
+* Add sorting by number of flights.
+* Re-sort Editor and Launch Window lists when they change.
+* Determine original order for assigned kerbals.
+* Add tooltips.
 
 
 ## Bugs
 
-There are no known bugs at the moment. Please file an issue if you find one!
+These are the known bugs at the moment. Please file an issue if you find another one!
+* When choosing a ship in the Launch Window, crew is auto-populated from the original order, not the sorted order. I am unsure how to fix this.
+* When removing a kerbal from a vehicle's crew roster in either the Editor or the Launch Window, the kerbal is not sorted back into the available list; instead they're just put at the top.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ If you have lots of kerbals, or are simply very organized, this is the mod for y
 ## To-Do
 
 * Add sorting by number of flights.
+* Add sorting of applicants in Astronaut Complex.
 * Determine original order for assigned kerbals.
 * Add tooltips.
 * Figure out how to change default crew auto-assignment.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ If you have lots of kerbals, or are simply very organized, this is the mod for y
 ## To-Do
 
 * Add sorting by number of flights.
-* Add sorting of applicants in Astronaut Complex.
 * Determine original order for assigned kerbals.
-* Add tooltips.
 * Figure out how to change default crew auto-assignment.
 * Add fly-in and fly-out animations for the sorting buttons on expansion and collapse?
+* Add compatibility with Oaktree42/KSI-Hiring by disabling the applicant sort bar when that mod is loaded.
 
 
 ## Bugs

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ If you have lots of kerbals, or are simply very organized, this is the mod for y
 * Determine original order for assigned kerbals.
 * Figure out how to change default crew auto-assignment.
 * Add fly-in and fly-out animations for the sorting buttons on expansion and collapse?
-* Add compatibility with Oaktree42/KSI-Hiring by disabling the applicant sort bar when that mod is loaded.
 
 
 ## Bugs

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ These are the known bugs at the moment. Please file an issue if you find another
 * In the Launch Windows and Editors, when dragging and dropping a kerbal into the list of available crew, the kerbal is not sorted back into the available list. I seem to have no way to detect when this is done, nor any way to disable it. If you drag and drop your kerbals, you can click on one of the kerbals in the available list to re-sort them.
 
 
+## How to Contribute
+Just fork it and submit a pull request when you've made the changes you want to see!
+
+Setting up the project is easy. All you need to do is create a folder called "lib" in the base folder of the project, then copy the Assembly-CSharp and UnityEngine DLLs from your installation of KSP into that folder.
+
+This project requires Visual Studio 2012 or greater. It should be compatible with the free version, and with newer versions.
+
+
 ## License
 
 The code in this repository is licensed under the BSD 3-Clause license. Please see the LICENSE file included in this repo and in every release for the full text.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ If you have lots of kerbals, or are simply very organized, this is the mod for y
 
 ## To-Do
 
-* Add sorting by number of flights.
-* Determine original order for assigned kerbals.
 * Figure out how to change default crew auto-assignment.
 * Add fly-in and fly-out animations for the sorting buttons on expansion and collapse?
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you have lots of kerbals, or are simply very organized, this is the mod for y
 ## To-Do
 
 * Add sorting by number of flights.
-* Re-sort Editor and Launch Window lists when they change.
+* Re-sort Editor list when it changes.
 * Determine original order for assigned kerbals.
 * Add tooltips.
 
@@ -26,8 +26,8 @@ If you have lots of kerbals, or are simply very organized, this is the mod for y
 ## Bugs
 
 These are the known bugs at the moment. Please file an issue if you find another one!
-* When choosing a ship in the Launch Window, crew is auto-populated from the original order, not the sorted order. I am unsure how to fix this.
-* When removing a kerbal from a vehicle's crew roster in either the Editor or the Launch Window, the kerbal is not sorted back into the available list; instead they're just put at the top.
+* In the Editor, when removing a kerbal from a vehicle's crew roster, the kerbal is not sorted back into the available list; instead they're just put at the top.
+* In the Launch Window, when dragging and dropping a kerbal into the list of available crew, the kerbal is not sorted back into the available list. I seem to have no way to detect when this is done, nor any way to disable it.
 
 
 ## License

--- a/SortBar.cs
+++ b/SortBar.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace KerbalSorter {
     // Unity apparently doesn't like generics, which would be very useful here. Way to go, Unity.
-    public class SortingButtons : MonoBehaviour {
+    public class SortBar : MonoBehaviour {
         private Roster<IUIListObject> roster = null;
         private SortButtonDef[] buttons = new SortButtonDef[0];
         private int[] buttonStates = new int[0];

--- a/SortBar.cs
+++ b/SortBar.cs
@@ -3,6 +3,7 @@ using System;
 using UnityEngine;
 using System.Collections.Generic;
 
+// Consider using Tooltips.TooltipController
 namespace KerbalSorter {
     // Unity apparently doesn't like generics, which would be very useful here. Way to go, Unity.
 
@@ -35,6 +36,10 @@ namespace KerbalSorter {
         /// The style of the displayed buttons.
         /// </summary>
         GUIStyle buttonStyle;
+        /// <summary>
+        /// The style of the displayed tooltip.
+        /// </summary>
+        GUIStyle tooltipStyle;
         /// <summary>
         /// Is the style set up yet?
         /// </summary>
@@ -117,6 +122,11 @@ namespace KerbalSorter {
                 buttonStyle = new GUIStyle(HighLogic.Skin.button);
                 buttonStyle.padding = new RectOffset(4, 4, 4, 4);
                 skinSetup = true;
+                tooltipStyle = new GUIStyle(GUI.skin.textField);
+                tooltipStyle.padding.top += 2;
+                tooltipStyle.padding.bottom += 2;
+                tooltipStyle.padding.left += 2;
+                tooltipStyle.padding.right += 2;
             }
 
             Texture buttonIcon = GameDatabase.Instance.GetTexture("KerbalSorter/Images/" + (expanded ? "SortBtnIn" : "SortBtnOut"), false);
@@ -145,6 +155,11 @@ namespace KerbalSorter {
 
             if( masterPressed ) {
                 expanded = !expanded;
+            }
+
+            if( GUI.tooltip != null && GUI.tooltip != "" ){
+                Vector2 size = tooltipStyle.CalcSize(new GUIContent(GUI.tooltip));
+                GUI.TextField(new Rect(x, y - size.y, size.x, size.y), GUI.tooltip, tooltipStyle);
             }
 
             // Do sorting:

--- a/SortBar.cs
+++ b/SortBar.cs
@@ -5,49 +5,113 @@ using System.Collections.Generic;
 
 namespace KerbalSorter {
     // Unity apparently doesn't like generics, which would be very useful here. Way to go, Unity.
+
+    /// <summary>
+    /// Class representing the KerbalSorter Sort Bar.
+    /// </summary>
     public class SortBar : MonoBehaviour {
+        /// <summary>
+        /// The Roster that we're sorting.
+        /// </summary>
         private Roster<IUIListObject> roster = null;
+        /// <summary>
+        /// The buttons to display.
+        /// </summary>
         private SortButtonDef[] buttons = new SortButtonDef[0];
+        /// <summary>
+        /// Each of the buttons' states.
+        /// </summary>
         private int[] buttonStates = new int[0];
+        /// <summary>
+        /// X position on the screen.
+        /// </summary>
         float x = 0;
+        /// <summary>
+        /// Y position on the screen.
+        /// </summary>
         float y = 0;
 
+        /// <summary>
+        /// The style of the displayed buttons.
+        /// </summary>
         GUIStyle buttonStyle;
+        /// <summary>
+        /// Is the style set up yet?
+        /// </summary>
         bool skinSetup = false;
+        /// <summary>
+        /// Is the bar expanded?
+        /// </summary>
         bool expanded = false;
 
+        /// <summary>
+        /// The order in which the user selected the buttons.
+        /// </summary>
         List<int> buttonSelectOrder = new List<int>();
+        /// <summary>
+        /// Have we already sorted the roster?
+        /// </summary>
         bool sorted = false;
 
+        /// <summary>
+        /// The base order of the roster.
+        /// </summary>
+        /// If null, no base order is set.
         KerbalComparer defaultOrder = null;
 
         // Apparently we can't use constructors in Unity, so we'll have to deal with it this way:
+        /// <summary>
+        /// Sets the roster that this Sort Bar will sort.
+        /// </summary>
+        /// <param name="roster">The Roster to sort</param>
         public void SetRoster(Roster<IUIListObject> roster) {
             this.roster = roster;
             this.sorted = false;
         }
+        /// <summary>
+        /// Sets the buttons to display in this Sort Bar.
+        /// </summary>
+        /// <param name="buttons">The list of button definitions to use</param>
         public void SetButtons(SortButtonDef[] buttons) {
             this.buttons = buttons;
             this.buttonStates = new int[buttons.Length];
             this.buttonSelectOrder.Clear();
         }
+        /// <summary>
+        /// Sets the position of the Sort Bar on the screen.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
         public void SetPos(float x, float y) {
             this.x = x;
             this.y = y;
         }
+        /// <summary>
+        /// Sets the base ordering of the Roster.
+        /// </summary>
+        /// <param name="comp">The function defining the base ordering</param>
         public void SetDefaultOrdering(KerbalComparer comp) {
             defaultOrder = comp;
         }
 
 
+        /// <summary>
+        /// Called when the enable property is set to true. DO NOT CALL DIRECTLY.
+        /// </summary>
         protected void OnEnable() {
             sorted = false;
         }
+        /// <summary>
+        /// Called when the enable property is set to false. DO NOT CALL DIRECTLY.
+        /// </summary>
         protected void OnDisable() {
             expanded = false;
         }
 
 
+        /// <summary>
+        /// Called to update the GUI. DO NOT CALL DIRECTLY.
+        /// </summary>
         protected void OnGUI() {
             if( !skinSetup ) {
                 buttonStyle = new GUIStyle(HighLogic.Skin.button);
@@ -87,6 +151,10 @@ namespace KerbalSorter {
             SortRoster(false);
         }
 
+        /// <summary>
+        /// Sorts the Roster.
+        /// </summary>
+        /// <param name="force">Force re-sorting? (Default: true)</param>
         public void SortRoster(bool force = true) {
             if( roster != null && (!sorted || force) ) {
                 int count = buttonSelectOrder.Count;
@@ -109,7 +177,16 @@ namespace KerbalSorter {
         }
     }
 
+    /// <summary>
+    /// Static class that actually does the sorting.
+    /// </summary>
+    /// <typeparam name="T">The type held in the Roster.</typeparam>
     public static class CrewSorter<T> {
+        /// <summary>
+        /// Sorts the given Roster using the given comparison functions.
+        /// </summary>
+        /// <param name="roster">The Roster to sort</param>
+        /// <param name="comparisons">The Comparisons to use, in order of application</param>
         public static void SortRoster(Roster<T> roster, KerbalComparer[] comparisons) {
             //Retrieve and temporarily store the list of kerbals
             T[] sortedRoster = new T[roster.Count];

--- a/SortingButtons.cs
+++ b/SortingButtons.cs
@@ -20,6 +20,8 @@ namespace KerbalSorter
         List<int> buttonSelectOrder = new List<int>();
         bool sorted = false;
 
+        KerbalComparer defaultOrder = null;
+
         // Apparently we can't use constructors in Unity, so we'll have to deal with it this way:
         public void SetRoster(Roster<IUIListObject> roster) {
             this.roster = roster;
@@ -33,6 +35,9 @@ namespace KerbalSorter
         public void SetPos(float x, float y) {
             this.x = x;
             this.y = y;
+        }
+        public void SetDefaultOrdering(KerbalComparer comp){
+            defaultOrder = comp;
         }
 
 
@@ -85,10 +90,19 @@ namespace KerbalSorter
 
         public void SortRoster(bool force = true) {
             if( roster != null && (!sorted || force) ){
-                KerbalComparer[] comparisons = new KerbalComparer[buttonSelectOrder.Count];
-                for( int i = 0; i < comparisons.Length; i++ ){
+                int count = buttonSelectOrder.Count;
+                int off = 0;
+                if( defaultOrder != null ) {
+                    count++;
+                    off++;
+                }
+                KerbalComparer[] comparisons = new KerbalComparer[count];
+                if( defaultOrder != null ){
+                    comparisons[0] = defaultOrder;
+                }
+                for( int i = 0; i < buttonSelectOrder.Count; i++ ){
                     int bIdx = buttonSelectOrder[i];
-                    comparisons[i] = buttons[bIdx].comparers[buttonStates[bIdx]];
+                    comparisons[i+off] = buttons[bIdx].comparers[buttonStates[bIdx]];
                 }
                 CrewSorter<IUIListObject>.SortRoster(roster, comparisons);
                 sorted = true;

--- a/SortingButtons.cs
+++ b/SortingButtons.cs
@@ -80,11 +80,11 @@ namespace KerbalSorter
             }
 
             // Do sorting:
-            SortRoster();
+            SortRoster(false);
         }
 
-        public void SortRoster() {
-            if( roster != null && !sorted ){
+        public void SortRoster(bool force = true) {
+            if( roster != null && (!sorted || force) ){
                 KerbalComparer[] comparisons = new KerbalComparer[buttonSelectOrder.Count];
                 for( int i = 0; i < comparisons.Length; i++ ){
                     int bIdx = buttonSelectOrder[i];

--- a/SortingButtons.cs
+++ b/SortingButtons.cs
@@ -3,8 +3,7 @@ using System;
 using UnityEngine;
 using System.Collections.Generic;
 
-namespace KerbalSorter
-{
+namespace KerbalSorter {
     // Unity apparently doesn't like generics, which would be very useful here. Way to go, Unity.
     public class SortingButtons : MonoBehaviour {
         private Roster<IUIListObject> roster = null;
@@ -36,7 +35,7 @@ namespace KerbalSorter
             this.x = x;
             this.y = y;
         }
-        public void SetDefaultOrdering(KerbalComparer comp){
+        public void SetDefaultOrdering(KerbalComparer comp) {
             defaultOrder = comp;
         }
 
@@ -50,28 +49,28 @@ namespace KerbalSorter
 
 
         protected void OnGUI() {
-            if( !skinSetup ){
+            if( !skinSetup ) {
                 buttonStyle = new GUIStyle(HighLogic.Skin.button);
-                buttonStyle.padding = new RectOffset(4,4,4,4);
+                buttonStyle.padding = new RectOffset(4, 4, 4, 4);
                 skinSetup = true;
             }
 
-            Texture buttonIcon = GameDatabase.Instance.GetTexture("KerbalSorter/Images/" + (expanded?"SortBtnIn":"SortBtnOut"), false);
+            Texture buttonIcon = GameDatabase.Instance.GetTexture("KerbalSorter/Images/" + (expanded ? "SortBtnIn" : "SortBtnOut"), false);
             string hoverText = "Sorting Options";
-            bool masterPressed = GUI.Button(new Rect(x,y , 25,25), new GUIContent(buttonIcon, hoverText), buttonStyle);
+            bool masterPressed = GUI.Button(new Rect(x, y, 25, 25), new GUIContent(buttonIcon, hoverText), buttonStyle);
 
             // Draw the sorting buttons.
-            if( expanded ){
-                float nextX = x+25;
+            if( expanded ) {
+                float nextX = x + 25;
 
-                for( int i = 0; i < buttons.Length; i++ ){
+                for( int i = 0; i < buttons.Length; i++ ) {
                     buttonIcon = GameDatabase.Instance.GetTexture(buttons[i].iconLocs[buttonStates[i]], false);
                     hoverText = buttons[i].hoverText[buttonStates[i]];
-                    bool pressed = GUI.Button(new Rect(nextX,y , 25,25), new GUIContent(buttonIcon,hoverText), buttonStyle);
-                    if( pressed ){
-                        buttonStates[i] = (buttonStates[i]+1) % buttons[i].numStates;
+                    bool pressed = GUI.Button(new Rect(nextX, y, 25, 25), new GUIContent(buttonIcon, hoverText), buttonStyle);
+                    if( pressed ) {
+                        buttonStates[i] = (buttonStates[i] + 1) % buttons[i].numStates;
                         buttonSelectOrder.Remove(i);
-                        if( buttonStates[i] != 0 ){
+                        if( buttonStates[i] != 0 ) {
                             buttonSelectOrder.Add(i);
                         }
                         sorted = false;
@@ -80,7 +79,7 @@ namespace KerbalSorter
                 }
             }
 
-            if( masterPressed ){
+            if( masterPressed ) {
                 expanded = !expanded;
             }
 
@@ -89,7 +88,7 @@ namespace KerbalSorter
         }
 
         public void SortRoster(bool force = true) {
-            if( roster != null && (!sorted || force) ){
+            if( roster != null && (!sorted || force) ) {
                 int count = buttonSelectOrder.Count;
                 int off = 0;
                 if( defaultOrder != null ) {
@@ -97,12 +96,12 @@ namespace KerbalSorter
                     off++;
                 }
                 KerbalComparer[] comparisons = new KerbalComparer[count];
-                if( defaultOrder != null ){
+                if( defaultOrder != null ) {
                     comparisons[0] = defaultOrder;
                 }
-                for( int i = 0; i < buttonSelectOrder.Count; i++ ){
+                for( int i = 0; i < buttonSelectOrder.Count; i++ ) {
                     int bIdx = buttonSelectOrder[i];
-                    comparisons[i+off] = buttons[bIdx].comparers[buttonStates[bIdx]];
+                    comparisons[i + off] = buttons[bIdx].comparers[buttonStates[bIdx]];
                 }
                 CrewSorter<IUIListObject>.SortRoster(roster, comparisons);
                 sorted = true;
@@ -114,19 +113,19 @@ namespace KerbalSorter
         public static void SortRoster(Roster<T> roster, KerbalComparer[] comparisons) {
             //Retrieve and temporarily store the list of kerbals
             T[] sortedRoster = new T[roster.Count];
-            for (int i = 0; i < roster.Count; i++) {
+            for( int i = 0; i < roster.Count; i++ ) {
                 sortedRoster[i] = roster.GetItem(i);
             }
 
             //Run through each comparison:
-            for (int a = 0; a < comparisons.Length; a++) {
+            for( int a = 0; a < comparisons.Length; a++ ) {
                 var compare = comparisons[a];
 
                 //Insertion sort, since it's stable and we don't have a large roster:
-                for (int i = 1; i < sortedRoster.Length; i++) {
+                for( int i = 1; i < sortedRoster.Length; i++ ) {
                     T kerbal = sortedRoster[i];
                     int k = i;
-                    while (0 < k && compare(roster.GetKerbal(kerbal), roster.GetKerbal(sortedRoster[k - 1])) < 0) {
+                    while( 0 < k && compare(roster.GetKerbal(kerbal), roster.GetKerbal(sortedRoster[k - 1])) < 0 ) {
                         sortedRoster[k] = sortedRoster[k - 1];
                         k--;
                     }
@@ -135,10 +134,10 @@ namespace KerbalSorter
             }
 
             //Apply the new order to the roster:
-            while( roster.Count > 0 ){
+            while( roster.Count > 0 ) {
                 roster.RemoveItem(0);
             }
-            for (int i = 0; i < sortedRoster.Length; i++) {
+            for( int i = 0; i < sortedRoster.Length; i++ ) {
                 roster.InsertItem(sortedRoster[i], i);
             }
         }

--- a/SortingInterface.cs
+++ b/SortingInterface.cs
@@ -4,6 +4,10 @@ using UnityEngine;
 using System.Collections.Generic;
 
 namespace KerbalSorter {
+    /// <summary>
+    /// An interface to a generic roster of Kerbals.
+    /// </summary>
+    /// <typeparam name="T">The type contained in the Roster</typeparam>
     public interface Roster<T> {
         int Count { get; }
         T GetItem(int index);
@@ -13,13 +17,31 @@ namespace KerbalSorter {
         ProtoCrewMember GetKerbal(T item);
     }
 
+    /// <summary>
+    /// A definition of a button used by the SortBar class.
+    /// </summary>
     public struct SortButtonDef {
-        public int numStates; //Must be >= 1. State 0 should be the default.
+        /// <summary>
+        /// The number of states this button has. Must be greater than 0. State 0 is the default state.
+        /// </summary>
+        public int numStates;
+        /// <summary>
+        /// The locations of the icons for each state of the button within the GameData directory.
+        /// </summary>
         public string[] iconLocs;
+        /// <summary>
+        /// The hover text for each state of the button.
+        /// </summary>
         public string[] hoverText;
+        /// <summary>
+        /// The Comparer to use for each state of the button.
+        /// </summary>
         public KerbalComparer[] comparers;
     }
 
+    /// <summary>
+    /// A static class defining the standard buttons.
+    /// </summary>
     public static class StandardButtonDefs {
         static public string BaseDir = "KerbalSorter/Images/";
         static public SortButtonDef ByName = new SortButtonDef{
@@ -75,15 +97,36 @@ namespace KerbalSorter {
         };
     }
 
+    /// <summary>
+    /// Compares two kerbals. For use in sorting.
+    /// </summary>
+    /// <param name="a"></param>
+    /// <param name="b"></param>
+    /// <returns>Negative if a comes before b,
+    ///          Zero if a and b are equivalent,
+    ///          Positive if a comes after b.</returns>
     public delegate int KerbalComparer(ProtoCrewMember a, ProtoCrewMember b);
+
+    /// <summary>
+    /// A static class defining the standard comparers.
+    /// </summary>
     public static class StandardKerbalComparers {
+        /// <summary>
+        /// Sorts by kerbal name alphabetically; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
         static public int NameAscending(ProtoCrewMember a, ProtoCrewMember b) {
             return a.name.CompareTo(b.name);
         }
+        /// <summary>
+        /// Sorts by kerbal name in reverse alphabetical order; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
         static public int NameDescending(ProtoCrewMember a, ProtoCrewMember b) {
             return -NameAscending(a, b);
         }
 
+        /// <summary>
+        /// Sorts Engineers first, then by class name alphabetically; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
         static public int ClassEngineersFirst(ProtoCrewMember a, ProtoCrewMember b) {
             bool aIsEng = a.experienceTrait.Title == "Engineer";
             bool bIsEng = b.experienceTrait.Title == "Engineer";
@@ -97,6 +140,9 @@ namespace KerbalSorter {
                 return a.experienceTrait.Title.CompareTo(b.experienceTrait.Title);
             }
         }
+        /// <summary>
+        /// Sorts Pilots first, then by class name alphabetically; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
         static public int ClassPilotsFirst(ProtoCrewMember a, ProtoCrewMember b) {
             bool aIsPil = a.experienceTrait.Title == "Pilot";
             bool bIsPil = b.experienceTrait.Title == "Pilot";
@@ -110,6 +156,9 @@ namespace KerbalSorter {
                 return a.experienceTrait.Title.CompareTo(b.experienceTrait.Title);
             }
         }
+        /// <summary>
+        /// Sorts Scientists first, then by class name alphabetically; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
         static public int ClassScientistsFirst(ProtoCrewMember a, ProtoCrewMember b) {
             bool aIsSci = a.experienceTrait.Title == "Scientist";
             bool bIsSci = b.experienceTrait.Title == "Scientist";
@@ -124,31 +173,60 @@ namespace KerbalSorter {
             }
         }
 
+        /// <summary>
+        /// Sorts by level, lower levels first; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
         static public int LevelAscending(ProtoCrewMember a, ProtoCrewMember b) {
             return a.experienceLevel - b.experienceLevel;
         }
+        /// <summary>
+        /// Sorts by level, higher levels first; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
         static public int LevelDescending(ProtoCrewMember a, ProtoCrewMember b) {
             return -LevelAscending(a, b);
         }
-
+        
+        /// <summary>
+        /// Sorts by gender, male first; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
         static public int GenderAscending(ProtoCrewMember a, ProtoCrewMember b) {
             return a.gender - b.gender;
         }
+        /// <summary>
+        /// Sorts by gender, female first; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
         static public int GenderDescending(ProtoCrewMember a, ProtoCrewMember b) {
             return -GenderAscending(a, b);
         }
 
+        /// <summary>
+        /// Sorts by number of completed flights, lower numbers first; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
         static public int NumFlightsAscending(ProtoCrewMember a, ProtoCrewMember b) {
             return a.flightLog.Entries.Count - b.flightLog.Entries.Count;
         }
+        /// <summary>
+        /// Sorts by number of completed flights, higher numbers first; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
         static public int NumFlightsDescending(ProtoCrewMember a, ProtoCrewMember b) {
             return -NumFlightsAscending(a, b);
         }
 
+        /// <summary>
+        /// No sorting; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
+        /// <returns>0</returns>
         static public int None(ProtoCrewMember a, ProtoCrewMember b) {
             return 0;
         }
 
+        /// <summary>
+        /// Sorts by the default order kerbals appear in the Available lists; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
+        /// The default order that kerbals appear in is the order in which the
+        /// kerbals appear in the save file. Under normal circumstances, the
+        /// order in which the kerbals appear in the save file is the order in
+        /// which they were hired.
         static public int DefaultAvailable(ProtoCrewMember a, ProtoCrewMember b) {
             if( a == b ) {
                 return 0;
@@ -162,10 +240,22 @@ namespace KerbalSorter {
             return 0;
         }
 
+        /// <summary>
+        /// Sorts by the default order kerbals appear in the Assigned lists; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
+        /// Currently I don't know exactly how this is ordered, so this just
+        /// returns 0 for now.
         static public int DefaultAssigned(ProtoCrewMember a, ProtoCrewMember b) {
             return 0;
         }
 
+        /// <summary>
+        /// Sorts by the default order kerbals appear in the Killed lists; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
+        /// The default order that kerbals appear in is the order in which the
+        /// kerbals appear in the save file. Under normal circumstances, the
+        /// order in which the kerbals appear in the save file is the order in
+        /// which they were hired.
         static public int DefaultKilled(ProtoCrewMember a, ProtoCrewMember b) {
             // Apparently Killed kerbals appear in the same order they would be if they were available.
             return DefaultAvailable(a,b);

--- a/SortingInterface.cs
+++ b/SortingInterface.cs
@@ -265,9 +265,26 @@ namespace KerbalSorter {
         /// <summary>
         /// Sorts by the default order kerbals appear in the Assigned list; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
         /// </summary>
-        /// Currently I don't know exactly how this is ordered, so this just
-        /// returns 0 for now.
+        /// The default order that kerbals appear in seems to be the order in
+        /// which the vessels appear in the save file. Under normal
+        /// circumstances, this is the order in which the vessels popped into
+        /// the universe, either by launching them or by undocking/decoupling
+        /// them from another vessel. Then, kerbals are ordered by the order
+        /// in which they appear within the vessel. Generally this is based on
+        /// their distance to the root part of the vessel, and their seat.
         static public int DefaultAssigned(ProtoCrewMember a, ProtoCrewMember b) {
+            if( a == b ) {
+                return 0;
+            }
+            foreach( ProtoVessel vessel in HighLogic.CurrentGame.flightState.protoVessels ) {
+                foreach( ProtoCrewMember kerbal in vessel.GetVesselCrew() ) {
+                    if( kerbal == a )
+                        return -1;
+                    if( kerbal == b )
+                        return 1;
+                }
+            }
+            // Uuuuum, neither are assigned?
             return 0;
         }
 

--- a/SortingInterface.cs
+++ b/SortingInterface.cs
@@ -149,5 +149,27 @@ namespace KerbalSorter
         static public int None(ProtoCrewMember a, ProtoCrewMember b) {
             return 0;
         }
+
+        static public int DefaultAvailable(ProtoCrewMember a, ProtoCrewMember b) {
+            if( a == b ){
+                return 0;
+            }
+            KerbalRoster roster = HighLogic.CurrentGame.CrewRoster;
+            foreach( ProtoCrewMember kerbal in roster.Crew ){
+                if( kerbal == a ) return -1;
+                if( kerbal == b ) return 1;
+            }
+            // Uuuuum, neither are in the roster?
+            return 0;
+        }
+
+        static public int DefaultAssigned(ProtoCrewMember a, ProtoCrewMember b) {
+            return 0;
+        }
+
+        static public int DefaultKilled(ProtoCrewMember a, ProtoCrewMember b) {
+            // Apparently Killed kerbals appear in the same order they would be if they were available.
+            return DefaultAvailable(a,b);
+        }
     }
 }

--- a/SortingInterface.cs
+++ b/SortingInterface.cs
@@ -3,10 +3,9 @@ using System;
 using UnityEngine;
 using System.Collections.Generic;
 
-namespace KerbalSorter
-{
+namespace KerbalSorter {
     public interface Roster<T> {
-        int Count{ get; }
+        int Count { get; }
         T GetItem(int index);
         void RemoveItem(int index);
         void InsertItem(T item, int index);
@@ -88,11 +87,11 @@ namespace KerbalSorter
         static public int ClassEngineersFirst(ProtoCrewMember a, ProtoCrewMember b) {
             bool aIsEng = a.experienceTrait.Title == "Engineer";
             bool bIsEng = b.experienceTrait.Title == "Engineer";
-            if( aIsEng && bIsEng ){
+            if( aIsEng && bIsEng ) {
                 return 0;
-            } else if( aIsEng ){
+            } else if( aIsEng ) {
                 return -1;
-            } else if( bIsEng ){
+            } else if( bIsEng ) {
                 return 1;
             } else {
                 return a.experienceTrait.Title.CompareTo(b.experienceTrait.Title);
@@ -101,11 +100,11 @@ namespace KerbalSorter
         static public int ClassPilotsFirst(ProtoCrewMember a, ProtoCrewMember b) {
             bool aIsPil = a.experienceTrait.Title == "Pilot";
             bool bIsPil = b.experienceTrait.Title == "Pilot";
-            if( aIsPil && bIsPil ){
+            if( aIsPil && bIsPil ) {
                 return 0;
-            } else if( aIsPil ){
+            } else if( aIsPil ) {
                 return -1;
-            } else if( bIsPil ){
+            } else if( bIsPil ) {
                 return 1;
             } else {
                 return a.experienceTrait.Title.CompareTo(b.experienceTrait.Title);
@@ -114,11 +113,11 @@ namespace KerbalSorter
         static public int ClassScientistsFirst(ProtoCrewMember a, ProtoCrewMember b) {
             bool aIsSci = a.experienceTrait.Title == "Scientist";
             bool bIsSci = b.experienceTrait.Title == "Scientist";
-            if( aIsSci && bIsSci ){
+            if( aIsSci && bIsSci ) {
                 return 0;
-            } else if( aIsSci ){
+            } else if( aIsSci ) {
                 return -1;
-            } else if( bIsSci ){
+            } else if( bIsSci ) {
                 return 1;
             } else {
                 return a.experienceTrait.Title.CompareTo(b.experienceTrait.Title);
@@ -151,11 +150,11 @@ namespace KerbalSorter
         }
 
         static public int DefaultAvailable(ProtoCrewMember a, ProtoCrewMember b) {
-            if( a == b ){
+            if( a == b ) {
                 return 0;
             }
             KerbalRoster roster = HighLogic.CurrentGame.CrewRoster;
-            foreach( ProtoCrewMember kerbal in roster.Crew ){
+            foreach( ProtoCrewMember kerbal in roster.Crew ) {
                 if( kerbal == a ) return -1;
                 if( kerbal == b ) return 1;
             }

--- a/SortingInterface.cs
+++ b/SortingInterface.cs
@@ -95,6 +95,18 @@ namespace KerbalSorter {
                                              StandardKerbalComparers.GenderAscending,
                                              StandardKerbalComparers.GenderDescending}
         };
+        static public SortButtonDef ByNumFlights = new SortButtonDef{
+            numStates = 3,
+            iconLocs = new string[]{ BaseDir+"SortFlights",
+                                     BaseDir+"SortFlightsAsc",
+                                     BaseDir+"SortFlightsDes"},
+            hoverText = new string[]{ "Sort by Number of Flights",
+                                      "Sort by Number of Flights, Ascending",
+                                      "Sort by Number of Flights, Descending"},
+            comparers = new KerbalComparer[]{StandardKerbalComparers.None,
+                                             StandardKerbalComparers.NumFlightsAscending,
+                                             StandardKerbalComparers.NumFlightsDescending}
+        };
     }
 
     /// <summary>
@@ -203,7 +215,7 @@ namespace KerbalSorter {
         /// Sorts by number of completed flights, lower numbers first; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
         /// </summary>
         static public int NumFlightsAscending(ProtoCrewMember a, ProtoCrewMember b) {
-            return a.flightLog.Entries.Count - b.flightLog.Entries.Count;
+            return a.careerLog.Entries.Count - b.careerLog.Entries.Count;
         }
         /// <summary>
         /// Sorts by number of completed flights, higher numbers first; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.

--- a/SortingInterface.cs
+++ b/SortingInterface.cs
@@ -241,7 +241,29 @@ namespace KerbalSorter {
         }
 
         /// <summary>
-        /// Sorts by the default order kerbals appear in the Assigned lists; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// Sorts by the default order kerbals appear in the Applicant list; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// </summary>
+        /// The default order that kerbals appear in is the order in which the
+        /// kerbals appear in the save file. Under normal circumstances, the
+        /// order in which the kerbals appear in the save file is the order in
+        /// which they were spawned.
+        static public int DefaultApplicant(ProtoCrewMember a, ProtoCrewMember b) {
+            if( a == b ) {
+                return 0;
+            }
+            KerbalRoster roster = HighLogic.CurrentGame.CrewRoster;
+            foreach( ProtoCrewMember kerbal in roster.Applicants ) {
+                if( kerbal == a )
+                    return -1;
+                if( kerbal == b )
+                    return 1;
+            }
+            // Uuuuum, neither are in the roster?
+            return 0;
+        }
+
+        /// <summary>
+        /// Sorts by the default order kerbals appear in the Assigned list; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
         /// </summary>
         /// Currently I don't know exactly how this is ordered, so this just
         /// returns 0 for now.
@@ -250,7 +272,7 @@ namespace KerbalSorter {
         }
 
         /// <summary>
-        /// Sorts by the default order kerbals appear in the Killed lists; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
+        /// Sorts by the default order kerbals appear in the Killed list; <see cref="KerbalSorter.KerbalComparer(ProtoCrewMember,ProtoCrewMember)"/>.
         /// </summary>
         /// The default order that kerbals appear in is the order in which the
         /// kerbals appear in the save file. Under normal circumstances, the


### PR DESCRIPTION
- Added tab-switch handling to Astronaut Complex.
- Added tool-tips to every button.
- Added SortBar to Applicants panel, with compatibility for OakTree42's KSI-Hiring mod.
- Added sorting by number of flights to all lists except the list of applicants.
- Added detection for Clear and Reset buttons in Editors and Launch Windows.
- Added detection for loading vessels in Editors.
- Added detection for selecting vessels in Launch Windows.
- Added fly-in animation to the Editor SortBar.
- Lists now revert to default orderings when no sorting is applied.
- Fixed bug where SortBars in Editors and Launch Windows would stay visible when jumping to Astronaut Complex.
